### PR TITLE
fix: Use getAllFromIndex instead of API for workshop thumbnails

### DIFF
--- a/.claude/agent-log.txt
+++ b/.claude/agent-log.txt
@@ -1,0 +1,1 @@
+[20260416-205806] stash@{0}: On master: agent-safety:session-start 20260416-205806

--- a/src/app/api/workshop/random/route.ts
+++ b/src/app/api/workshop/random/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getAllFromIndex } from "@/cms/lib/content-db-manager";
 import { listMarkdownPages } from "@/cms/server/markdown-service";
 
 export const runtime = "nodejs";
@@ -11,36 +12,17 @@ interface ArticleData {
 	thumbnail: string | null;
 }
 
-// Get thumbnail from CMS content
-async function getThumbnail(page: any): Promise<string | null> {
-	const contentId = page.contentId || page.slug;
-	try {
-		const baseUrl =
-			process.env.NODE_ENV === "development"
-				? "http://localhost:3010"
-				: process.env.NEXT_PUBLIC_SITE_URL ||
-					process.env.NEXT_PUBLIC_BASE_URL ||
-					"https://yusuke-kim.com";
-
-		const res = await fetch(
-			`${baseUrl}/api/cms/contents?id=${encodeURIComponent(contentId)}`,
-			{ cache: "no-store" },
-		);
-
-		if (res.ok) {
-			const cmsContent = await res.json();
-			if (cmsContent?.thumbnails) {
-				const thumbs = cmsContent.thumbnails;
-				if (thumbs?.image?.src) return thumbs.image.src;
-				if (thumbs?.gif?.src) return thumbs.gif.src;
-				if (thumbs?.webm?.poster) return thumbs.webm.poster;
-			}
-		}
-	} catch (error) {
-		console.error(`[Random API] Error fetching content ${contentId}:`, error);
+// Get thumbnail from CMS content using index (no API call)
+function getThumbnail(page: any, cmsContent: any): string | null {
+	// First try to get from CMS content (from index)
+	if (cmsContent?.thumbnails) {
+		const thumbs = cmsContent.thumbnails;
+		if (thumbs?.image?.src) return thumbs.image.src;
+		if (thumbs?.gif?.src) return thumbs.gif.src;
+		if (thumbs?.webm?.poster) return thumbs.webm.poster;
 	}
 
-	// Check frontmatter
+	// Then check frontmatter
 	const frontmatter = page.frontmatter ?? {};
 	const candidates = [
 		typeof frontmatter.thumbnail === "string" ? frontmatter.thumbnail : undefined,
@@ -98,25 +80,29 @@ export async function GET(request: NextRequest) {
 			return NextResponse.json({ articles: [] });
 		}
 
+		// Get all index data at once (optimization for N+1 problem)
+		const allIndex = getAllFromIndex();
+		const indexMap = new Map(allIndex.map((item) => [item.id, item]));
+
 		// Shuffle and pick random articles
 		const shuffled = [...publishedContent].sort(() => Math.random() - 0.5);
 		const selectedPages = shuffled.slice(0, Math.min(limit, shuffled.length));
 
-		// Build article data
-		const articles: ArticleData[] = await Promise.all(
-			selectedPages.map(async (page) => {
-				const thumbnail = await getThumbnail(page);
-				const title = page.frontmatter?.title || page.slug;
-				const href = getPageHref(page);
+		// Build article data using index data (no API calls)
+		const articles: ArticleData[] = selectedPages.map((page) => {
+			const contentId = page.contentId || page.slug;
+			const cmsContent = indexMap.get(contentId);
+			const thumbnail = getThumbnail(page, cmsContent);
+			const title = page.frontmatter?.title || page.slug;
+			const href = getPageHref(page);
 
-				return {
-					slug: page.slug,
-					title,
-					href,
-					thumbnail,
-				};
-			}),
-		);
+			return {
+				slug: page.slug,
+				title,
+				href,
+				thumbnail,
+			};
+		});
 
 		return NextResponse.json({ articles });
 	} catch (error) {

--- a/src/app/api/workshop/related/route.ts
+++ b/src/app/api/workshop/related/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getContentTags } from "@/cms/lib/content-db-manager";
+import { getAllFromIndex, getContentTags } from "@/cms/lib/content-db-manager";
 import { listMarkdownPages } from "@/cms/server/markdown-service";
 
 export const runtime = "nodejs";
@@ -13,35 +13,17 @@ interface RelatedArticle {
 	tags: string[];
 }
 
-// Get thumbnail from CMS content
-async function getThumbnail(page: any): Promise<string | null> {
-	const contentId = page.contentId || page.slug;
-	try {
-		const baseUrl =
-			process.env.NODE_ENV === "development"
-				? "http://localhost:3010"
-				: process.env.NEXT_PUBLIC_SITE_URL ||
-					process.env.NEXT_PUBLIC_BASE_URL ||
-					"https://yusuke-kim.com";
-
-		const res = await fetch(
-			`${baseUrl}/api/cms/contents?id=${encodeURIComponent(contentId)}`,
-			{ cache: "no-store" },
-		);
-
-		if (res.ok) {
-			const cmsContent = await res.json();
-			if (cmsContent?.thumbnails) {
-				const thumbs = cmsContent.thumbnails;
-				if (thumbs?.image?.src) return thumbs.image.src;
-				if (thumbs?.gif?.src) return thumbs.gif.src;
-				if (thumbs?.webm?.poster) return thumbs.webm.poster;
-			}
-		}
-	} catch (error) {
-		console.error(`[Related API] Error fetching content ${contentId}:`, error);
+// Get thumbnail from CMS content using index (no API call)
+function getThumbnail(page: any, cmsContent: any): string | null {
+	// First try to get from CMS content (from index)
+	if (cmsContent?.thumbnails) {
+		const thumbs = cmsContent.thumbnails;
+		if (thumbs?.image?.src) return thumbs.image.src;
+		if (thumbs?.gif?.src) return thumbs.gif.src;
+		if (thumbs?.webm?.poster) return thumbs.webm.poster;
 	}
 
+	// Then check frontmatter
 	const frontmatter = page.frontmatter ?? {};
 	const candidates = [
 		typeof frontmatter.thumbnail === "string" ? frontmatter.thumbnail : undefined,
@@ -111,6 +93,10 @@ export async function GET(request: NextRequest) {
 			return NextResponse.json({ articles: [] });
 		}
 
+		// Get all index data at once (optimization for N+1 problem)
+		const allIndex = getAllFromIndex();
+		const indexMap = new Map(allIndex.map((item) => [item.id, item]));
+
 		// Build tags map for all pages
 		const articlesWithTags: Array<{
 			page: any;
@@ -134,22 +120,22 @@ export async function GET(request: NextRequest) {
 		const shuffled = related.sort(() => Math.random() - 0.5);
 		const selected = shuffled.slice(0, Math.min(limit, shuffled.length));
 
-		// Build article data
-		const articles: RelatedArticle[] = await Promise.all(
-			selected.map(async ({ page, tags }) => {
-				const thumbnail = await getThumbnail(page);
-				const title = page.frontmatter?.title || page.slug;
-				const href = getPageHref(page);
+		// Build article data using index data (no API calls)
+		const articles: RelatedArticle[] = selected.map(({ page, tags }) => {
+			const contentId = page.contentId || page.slug;
+			const cmsContent = indexMap.get(contentId);
+			const thumbnail = getThumbnail(page, cmsContent);
+			const title = page.frontmatter?.title || page.slug;
+			const href = getPageHref(page);
 
-				return {
-					slug: page.slug,
-					title,
-					href,
-					thumbnail,
-					tags,
-				};
-			}),
-		);
+			return {
+				slug: page.slug,
+				title,
+				href,
+				thumbnail,
+				tags,
+			};
+		});
 
 		return NextResponse.json({ articles });
 	} catch (error) {


### PR DESCRIPTION
## Summary
- Update `/api/workshop/random` to use `getAllFromIndex()` for thumbnail retrieval
- Update `/api/workshop/related` to use `getAllFromIndex()` for thumbnail retrieval
- Remove API calls to `/api/cms/contents` for better performance
- Also includes Next.js downgrade to 15.x for Windows compatibility

## Problem
Workshop blog detail pages (`/workshop/blog/[slug]`) were not displaying thumbnails in the Article Side Panel (recommended articles) and Related Articles sections, even though thumbnails were working correctly on the main workshop page.

## Root Cause
The `/api/workshop/random` and `/api/workshop/related` APIs were making HTTP requests to `/api/cms/contents?id=xxx` to fetch thumbnail data, which was either failing or not returning the expected data structure.

## Solution
- Refactored both APIs to use `getAllFromIndex()` directly, matching the approach used in `workshop/page.tsx`
- This eliminates the N+1 API call problem and ensures consistent thumbnail retrieval
- Also synchronizes the `getThumbnail` function (no longer async)

## Test plan
- [x] Verify thumbnails display correctly in Article Side Panel on blog detail pages
- [x] Verify thumbnails display correctly in Related Articles section
- [x] Check that main workshop page still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to thumbnail lookup in two read-only endpoints; main risk is missing thumbnails if `contentId`/index entries don’t match expected IDs.
> 
> **Overview**
> Workshop sidebar/recommendation APIs no longer fetch per-article CMS data over HTTP. Both `/api/workshop/random` and `/api/workshop/related` now load `getAllFromIndex()` once, map it by `contentId`, and resolve `thumbnail` synchronously from index data with a frontmatter fallback, eliminating the N+1 `/api/cms/contents` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc07f9a47364c5c40a33e97e3e373ed872fecfdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ワークショップの関連記事取得時の処理フローを改善しました。
  * ランダムワークショップ記事選択時の処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->