### PR TITLE
deps(deps-dev): bump @types/node from 24.9.2 to 25.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.0",
 		"@types/jest": "^30.0.0",
-		"@types/node": "^24.9.2",
+		"@types/node": "^25.7.0",
 		"@types/p5": "^1.7.7",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",


### PR DESCRIPTION
Bumps @types/node from 24.9.2 to 25.7.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dev-only dependency bump; impact is limited to TypeScript type-checking and could surface new/changed Node typings during builds.
> 
> **Overview**
> Updates the dev dependency `@types/node` from `24.9.2` to `25.7.0` in `package.json`, refreshing Node.js TypeScript typings used during development and CI type-checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5188f9c379173601025092d14b8a0ec55866d42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->