### PR TITLE
Refactor Text Counter Tool and Enhance Functionality

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "gl-matrix": "^3.4.4",
         "gsap": "^3.13.0",
         "isomorphic-dompurify": "^2.30.1",
+        "js-tiktoken": "^1.0.21",
         "jszip": "^3.10.1",
         "lucide-react": "^0.548.0",
         "marked": "^16.4.1",
@@ -1821,6 +1822,8 @@
     "js-binary-schema-parser": ["js-binary-schema-parser@2.0.3", "", {}, "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg=="],
 
     "js-library-detector": ["js-library-detector@6.7.0", "", {}, "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA=="],
+
+    "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"gl-matrix": "^3.4.4",
 		"gsap": "^3.13.0",
 		"isomorphic-dompurify": "^2.30.1",
+		"js-tiktoken": "^1.0.21",
 		"jszip": "^3.10.1",
 		"lucide-react": "^0.548.0",
 		"marked": "^16.4.1",

--- a/src/app/about/AboutStitchClient.tsx
+++ b/src/app/about/AboutStitchClient.tsx
@@ -341,7 +341,7 @@ const siteLinks = [
 	{ href: "/portfolio", label: "Portfolio", desc: "制作したもの" },
 	{ href: "/workshop", label: "Workshop", desc: "ワークショップ" },
 	{ href: "/tools", label: "Tools", desc: "ツール集" },
-	{ href: "/links", label: "Links", desc: "リンク集" },
+	{ href: "/about/links", label: "Links", desc: "リンク集" },
 	{ href: "/search", label: "Search", desc: "検索" },
 ];
 

--- a/src/app/tools/ae-expression/components/AEExpressionTool.tsx
+++ b/src/app/tools/ae-expression/components/AEExpressionTool.tsx
@@ -917,62 +917,7 @@ ${generatedCode}`;
 		}
 	}, [generatedCode, selectedExpression]);
 
-	// Handle keyboard shortcuts
-	useEffect(() => {
-		const handleToolShortcut = (event: CustomEvent) => {
-			switch (event.detail.key.toLowerCase()) {
-				case "c":
-					if (generatedCode) {
-						copyToClipboard();
-					}
-					break;
-				case "p":
-					setIsPreviewPlaying(!isPreviewPlaying);
-					break;
-				case "r":
-					setPreviewTime(0);
-					setIsPreviewPlaying(false);
-					break;
-				case "s":
-					if (selectedExpression && generatedCode) {
-						saveExpression();
-					}
-					break;
-				case "d":
-					setShowDocumentation(!showDocumentation);
-					break;
-				case "e":
-					if (generatedCode) {
-						exportExpression();
-					}
-					break;
-				case "f":
-					if (selectedExpression) {
-						toggleFavorite(selectedExpression.id);
-					}
-					break;
-			}
-		};
 
-		document.addEventListener(
-			"toolShortcut",
-			handleToolShortcut as EventListener,
-		);
-		return () =>
-			document.removeEventListener(
-				"toolShortcut",
-				handleToolShortcut as EventListener,
-			);
-	}, [
-		generatedCode,
-		isPreviewPlaying,
-		copyToClipboard,
-		saveExpression,
-		showDocumentation,
-		exportExpression,
-		selectedExpression,
-		toggleFavorite,
-	]);
 
 	// Preview animation timer
 	useEffect(() => {
@@ -992,15 +937,6 @@ ${generatedCode}`;
 			toolName="AE Expression Tool"
 			description="AfterEffectsのエクスプレッションをScratch風ブロックUIで簡単に設定.アニメーション、エフェクト、変形などのエクスプレッションを一覧表示."
 			category="Design"
-			keyboardShortcuts={[
-				{ key: "c", description: "コードをコピー" },
-				{ key: "p", description: "プレビュー再生/停止" },
-				{ key: "r", description: "プレビューリセット" },
-				{ key: "s", description: "エクスプレッションを保存" },
-				{ key: "d", description: "ドキュメント表示切替" },
-				{ key: "e", description: "エクスプレッションをエクスポート" },
-				{ key: "f", description: "お気に入り切替" },
-			]}
 		>
 			<div className="space-y-8">
 				{/* Controls */}

--- a/src/app/tools/ae-expression/page.tsx
+++ b/src/app/tools/ae-expression/page.tsx
@@ -32,7 +32,7 @@ export const metadata = {
 export default function AEExpressionPage() {
 	return (
 		<>
-			<div className="relative min-h-screen bg-base text-main">
+			<div className="relative min-h-screen text-main">
 				<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
 					<div className="container-system">
 						<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/tools/business-mail-block/components/BusinessMailBlockTool.tsx
+++ b/src/app/tools/business-mail-block/components/BusinessMailBlockTool.tsx
@@ -689,54 +689,7 @@ export default function BusinessMailBlockTool() {
 		[templates],
 	);
 
-	// Handle keyboard shortcuts
-	useEffect(() => {
-		const handleToolShortcut = (event: CustomEvent) => {
-			switch (event.detail.key.toLowerCase()) {
-				case "c":
-					if (generatedEmail) {
-						copyToClipboard();
-					}
-					break;
-				case "d":
-					if (generatedEmail) {
-						downloadEmail();
-					}
-					break;
-				case "r":
-					setComposedBlocks([]);
-					setVariables({});
-					setSelectedTemplate("");
-					break;
-				case "t":
-					setShowTemplateLibrary(!showTemplateLibrary);
-					break;
-				case "v":
-					setShowValidation(!showValidation);
-					break;
-				case "g":
-					setShowGuidelines(!showGuidelines);
-					break;
-			}
-		};
 
-		document.addEventListener(
-			"toolShortcut",
-			handleToolShortcut as EventListener,
-		);
-		return () =>
-			document.removeEventListener(
-				"toolShortcut",
-				handleToolShortcut as EventListener,
-			);
-	}, [
-		generatedEmail,
-		copyToClipboard,
-		downloadEmail,
-		showTemplateLibrary,
-		showValidation,
-		showGuidelines,
-	]);
 
 	// Generate email when composed blocks or variables change
 	useEffect(() => {
@@ -761,14 +714,6 @@ export default function BusinessMailBlockTool() {
 			toolName="Business Mail Block Tool"
 			description="ビジネスメールをScratch風ブロックUIで簡単作成.挨拶、本文、締め、署名を組み合わせてプロフェッショナルなメールを作成.テンプレート機能とバリデーション機能付き."
 			category="Business"
-			keyboardShortcuts={[
-				{ key: "c", description: "メールをコピー" },
-				{ key: "d", description: "メールをダウンロード" },
-				{ key: "r", description: "全てリセット" },
-				{ key: "t", description: "テンプレートライブラリ表示切替" },
-				{ key: "v", description: "バリデーション表示切替" },
-				{ key: "g", description: "ガイドライン表示切替" },
-			]}
 		>
 			<DragDropContext onDragEnd={handleDragEnd}>
 				<div className="space-y-8">

--- a/src/app/tools/business-mail-block/page.tsx
+++ b/src/app/tools/business-mail-block/page.tsx
@@ -30,7 +30,7 @@ export const metadata = {
 export default function BusinessMailBlockPage() {
 	return (
 		<>
-			<div className="relative min-h-screen bg-base text-main">
+			<div className="relative min-h-screen text-main">
 				<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
 					<div className="container-system">
 						<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/tools/code-type-p5/page.tsx
+++ b/src/app/tools/code-type-p5/page.tsx
@@ -6,7 +6,7 @@ import { Breadcrumbs } from "@/components/ui/Breadcrumbs";
 const CodeTypeP5App = dynamic(() => import("./components/CodeTypeP5App"), {
 	ssr: false,
 	loading: () => (
-		<div className="flex items-center justify-center min-h-screen bg-base text-main">
+		<div className="flex items-center justify-center min-h-screen text-main">
 			<div className="text-center">
 				<div className="text-2xl mb-4">読み込み中...</div>
 				<div className="text-sm opacity-70">

--- a/src/app/tools/color-palette/components/ColorPaletteGenerator.tsx
+++ b/src/app/tools/color-palette/components/ColorPaletteGenerator.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import useOfflinePerformance from "@/hooks/useOfflinePerformance";
 import {
-	type ColorHarmony,
 	type ColorInfo,
 	generateColorHarmony,
 	generateGoldenRatioColors,
 	generatePerceptuallyUniformColors,
 	getAccessibilityInfo,
-	hexToRgb,
 	hsvToRgb,
 	randomInRange,
 	rgbToHex,
@@ -18,11 +15,8 @@ import {
 	sortColorsByLightness,
 	sortColorsBySaturation,
 } from "@/lib/utils/color";
-import AccessibleButton from "../../components/AccessibleButton";
-import OfflineSettingsManager from "../../components/OfflineSettingsManager";
-import ToolWrapper from "../../components/ToolWrapper";
+import { RawDOMContainer } from "../../components/RawDOMContainer";
 
-// Palette management interfaces
 interface SavedPalette {
 	id: string;
 	name: string;
@@ -31,7 +25,6 @@ interface SavedPalette {
 	tags: string[];
 }
 
-// Predefined color ranges with enhanced options
 const colorRangePresets = {
 	warm: { hMin: 0, hMax: 60, sMin: 50, sMax: 100, vMin: 40, vMax: 80 },
 	cool: { hMin: 180, hMax: 240, sMin: 50, sMax: 100, vMin: 40, vMax: 80 },
@@ -43,114 +36,58 @@ const colorRangePresets = {
 	sunset: { hMin: 300, hMax: 60, sMin: 60, sMax: 100, vMin: 50, vMax: 90 },
 	forest: { hMin: 80, hMax: 140, sMin: 40, sMax: 80, vMin: 20, vMax: 60 },
 	neon: { hMin: 0, hMax: 360, sMin: 90, sMax: 100, vMin: 80, vMax: 100 },
-};
+} as const;
 
-// Generation algorithms
 const generationAlgorithms = {
 	random: "Random HSV",
 	golden: "Golden Ratio",
 	perceptual: "Perceptually Uniform",
 	harmony: "Color Harmony",
-};
+} as const;
 
-// Settings interface for offline persistence
-interface ColorPaletteSettings extends Record<string, unknown> {
+interface ColorPaletteSettings {
 	colorCount: number;
 	hueRange: { min: number; max: number };
 	saturationRange: { min: number; max: number };
 	valueRange: { min: number; max: number };
 	exportFormat: "css" | "tailwind" | "json";
-	showAccessibility: boolean;
 	generationAlgorithm: keyof typeof generationAlgorithms;
-	harmonyType: ColorHarmony["type"];
 	sortBy: "none" | "hue" | "lightness" | "saturation";
-	enableColorBlindCheck: boolean;
 	autoSave: boolean;
 }
 
-export default function ColorPaletteGenerator() {
-	// Default settings
-	const defaultSettings: ColorPaletteSettings = {
-		colorCount: 5,
-		hueRange: { min: 0, max: 360 },
-		saturationRange: { min: 50, max: 100 },
-		valueRange: { min: 50, max: 90 },
-		exportFormat: "css",
-		showAccessibility: false,
-		generationAlgorithm: "random",
-		harmonyType: "analogous",
-		sortBy: "none",
-		enableColorBlindCheck: true,
-		autoSave: false,
-	};
+const defaultSettings: ColorPaletteSettings = {
+	colorCount: 5,
+	hueRange: { min: 0, max: 360 },
+	saturationRange: { min: 50, max: 100 },
+	valueRange: { min: 50, max: 90 },
+	exportFormat: "css",
+	generationAlgorithm: "random",
+	sortBy: "none",
+	autoSave: false,
+};
 
-	// State management
-	const [settings, setSettings] =
-		useState<ColorPaletteSettings>(defaultSettings);
+export default function ColorPaletteGenerator() {
+	const [settings, setSettings] = useState<ColorPaletteSettings>(defaultSettings);
 	const [generatedColors, setGeneratedColors] = useState<ColorInfo[]>([]);
 	const [savedPalettes, setSavedPalettes] = useState<SavedPalette[]>([]);
-	const [currentHarmony, setCurrentHarmony] = useState<ColorHarmony | null>(
-		null,
-	);
-	const [selectedColor, setSelectedColor] = useState<ColorInfo | null>(null);
-	const [importedPalette, setImportedPalette] = useState<string>("");
-	const [paletteSearch, setPaletteSearch] = useState<string>("");
-	const [showPaletteManager, setShowPaletteManager] = useState(false);
-	const [notification, setNotification] = useState<string>("");
+	const [notification, setNotification] = useState("");
+
 	const paletteIdRef = useRef(1);
 
-	// Refs for file operations
-	const fileInputRef = useRef<HTMLInputElement>(null);
-
-	// Destructure settings
-	const {
-		colorCount,
-		hueRange,
-		saturationRange,
-		valueRange,
-		exportFormat,
-		showAccessibility,
-		generationAlgorithm,
-		harmonyType,
-		sortBy,
-		enableColorBlindCheck,
-		autoSave,
-	} = settings;
-
-	// Performance optimization hook
-	const { measureTime } = useOfflinePerformance({
-		toolName: "color-palette",
-		enablePerformanceMonitoring: true,
-		enableOfflineNotifications: true,
-	});
-
-	// Enhanced keyboard shortcuts
-	const keyboardShortcuts = [
-		{ key: "G", description: "新しいパレット生成" },
-		{ key: "S", description: "パレット保存" },
-		{ key: "E", description: "エクスポート" },
-		{ key: "R", description: "リセット" },
-		{ key: "A", description: "アクセシビリティ表示切替" },
-		{ key: "H", description: "ハーモニー生成" },
-		{ key: "M", description: "パレット管理" },
-		{ key: "I", description: "パレットインポート" },
-	];
-
-	// Show notification
 	const showNotification = useCallback((message: string) => {
 		setNotification(message);
 		setTimeout(() => setNotification(""), 3000);
 	}, []);
 
-	// Generate random colors (original algorithm)
 	const generateRandomColors = useCallback((): ColorInfo[] => {
 		const colors: ColorInfo[] = [];
 		const usedColors = new Set<string>();
 
-		while (colors.length < colorCount) {
-			const h = randomInRange(hueRange.min, hueRange.max);
-			const s = randomInRange(saturationRange.min, saturationRange.max);
-			const v = randomInRange(valueRange.min, valueRange.max);
+		while (colors.length < settings.colorCount) {
+			const h = randomInRange(settings.hueRange.min, settings.hueRange.max);
+			const s = randomInRange(settings.saturationRange.min, settings.saturationRange.max);
+			const v = randomInRange(settings.valueRange.min, settings.valueRange.max);
 
 			const rgb = hsvToRgb(h, s, v);
 			const hex = rgbToHex(rgb.r, rgb.g, rgb.b);
@@ -160,23 +97,18 @@ export default function ColorPaletteGenerator() {
 				const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
 				const accessibility = getAccessibilityInfo(rgb);
 
-				colors.push({
-					hex,
-					rgb,
-					hsv: { h, s, v },
-					hsl,
-					accessibility,
-				});
+				colors.push({ hex, rgb, hsv: { h, s, v }, hsl, accessibility });
 			}
 		}
 
 		return colors;
-	}, [colorCount, hueRange, saturationRange, valueRange]);
+	}, [settings]);
 
-	// Enhanced palette saving with metadata
 	const savePalette = useCallback(
 		async (customName?: string) => {
-			if (generatedColors.length === 0) return;
+			if (generatedColors.length === 0) {
+				return;
+			}
 
 			const name = customName || `Palette ${savedPalettes.length + 1}`;
 			const newPalette: SavedPalette = {
@@ -184,7 +116,7 @@ export default function ColorPaletteGenerator() {
 				name,
 				colors: generatedColors,
 				createdAt: new Date().toISOString(),
-				tags: [generationAlgorithm, harmonyType],
+				tags: [settings.generationAlgorithm],
 			};
 
 			setSavedPalettes((prev) => [newPalette, ...prev]);
@@ -193,96 +125,56 @@ export default function ColorPaletteGenerator() {
 		[
 			generatedColors,
 			savedPalettes.length,
-			generationAlgorithm,
-			harmonyType,
+			settings.generationAlgorithm,
 			showNotification,
 		],
 	);
 
-	// Generate colors with advanced algorithms
 	const generateColors = useCallback(async () => {
-		const timedGeneration = measureTime((): ColorInfo[] => {
-			let colors: ColorInfo[] = [];
+		let colors: ColorInfo[] = [];
 
-			switch (generationAlgorithm) {
-				case "random":
-					colors = generateRandomColors();
-					break;
-				case "golden": {
-					const baseHue = randomInRange(hueRange.min, hueRange.max);
-					colors = generateGoldenRatioColors(baseHue, colorCount);
-					break;
-				}
-				case "perceptual":
-					colors = generatePerceptuallyUniformColors(colorCount);
-					break;
-				case "harmony":
-					if (selectedColor) {
-						const harmony = generateColorHarmony(
-							selectedColor.hsv,
-							harmonyType,
-						);
-						colors = harmony.colors.slice(0, colorCount);
-						setCurrentHarmony(harmony);
-					} else {
-						const baseH = randomInRange(hueRange.min, hueRange.max);
-						const baseS = randomInRange(
-							saturationRange.min,
-							saturationRange.max,
-						);
-						const baseV = randomInRange(valueRange.min, valueRange.max);
-						const harmony = generateColorHarmony(
-							{ h: baseH, s: baseS, v: baseV },
-							harmonyType,
-						);
-						colors = harmony.colors.slice(0, colorCount);
-						setCurrentHarmony(harmony);
-					}
-					break;
+		switch (settings.generationAlgorithm) {
+			case "random":
+				colors = generateRandomColors();
+				break;
+			case "golden": {
+				const baseHue = randomInRange(settings.hueRange.min, settings.hueRange.max);
+				colors = generateGoldenRatioColors(baseHue, settings.colorCount);
+				break;
 			}
-
-			// Apply sorting
-			switch (sortBy) {
-				case "hue":
-					colors = sortColorsByHue(colors);
-					break;
-				case "lightness":
-					colors = sortColorsByLightness(colors);
-					break;
-				case "saturation":
-					colors = sortColorsBySaturation(colors);
-					break;
-			}
-
-			return colors;
-		});
-
-		setGeneratedColors(timedGeneration.result as ColorInfo[]);
-
-		if (autoSave && (timedGeneration.result as ColorInfo[]).length > 0) {
-			await savePalette(`Auto-saved ${new Date().toLocaleTimeString()}`);
+			case "perceptual":
+				colors = generatePerceptuallyUniformColors(settings.colorCount);
+				break;
+			case "harmony":
+				const baseH = randomInRange(settings.hueRange.min, settings.hueRange.max);
+				const baseS = randomInRange(settings.saturationRange.min, settings.saturationRange.max);
+				const baseV = randomInRange(settings.valueRange.min, settings.valueRange.max);
+				colors = generateColorHarmony({ h: baseH, s: baseS, v: baseV }, "analogous").colors.slice(
+					0,
+					settings.colorCount,
+				);
+				break;
 		}
 
-		showNotification(
-			`${(timedGeneration.result as ColorInfo[]).length}色のパレットを生成しました`,
-		);
-	}, [
-		colorCount,
-		hueRange,
-		saturationRange,
-		valueRange,
-		generationAlgorithm,
-		harmonyType,
-		sortBy,
-		selectedColor,
-		autoSave,
-		measureTime,
-		showNotification,
-		generateRandomColors,
-		savePalette,
-	]);
+		switch (settings.sortBy) {
+			case "hue":
+				colors = sortColorsByHue(colors);
+				break;
+			case "lightness":
+				colors = sortColorsByLightness(colors);
+				break;
+			case "saturation":
+				colors = sortColorsBySaturation(colors);
+				break;
+		}
 
-	// Apply preset color range
+		setGeneratedColors(colors);
+		if (settings.autoSave && colors.length > 0) {
+			await savePalette(`Auto-saved ${new Date().toLocaleTimeString()}`);
+		}
+		showNotification(`${colors.length}色のパレットを生成しました`);
+	}, [settings, generateRandomColors, savePalette, showNotification]);
+
 	const applyPreset = (preset: keyof typeof colorRangePresets) => {
 		const range = colorRangePresets[preset];
 		setSettings((prev) => ({
@@ -294,1072 +186,355 @@ export default function ColorPaletteGenerator() {
 		showNotification(`${preset}プリセットを適用しました`);
 	};
 
-	// Load saved palette
-	const loadPalette = (palette: SavedPalette) => {
-		setGeneratedColors(palette.colors);
-		showNotification(`パレット "${palette.name}" を読み込みました`);
-	};
-
-	// Delete saved palette
-	const deletePalette = (id: string) => {
-		setSavedPalettes((prev) => prev.filter((p) => p.id !== id));
-		showNotification("パレットを削除しました");
-	};
-
-	// Enhanced export functions
 	const exportAsCSS = useCallback(() => {
-		const cssVars = generatedColors
-			.map((color, index) => `  --color-${index + 1}: ${color.hex};`)
-			.join("\n");
+		const cssVars = generatedColors.map((color, index) => `  --color-${index + 1}: ${color.hex};`).join("\n");
 		return `:root {\n${cssVars}\n}`;
 	}, [generatedColors]);
 
 	const exportAsTailwind = useCallback(() => {
-		const colors = generatedColors.reduce(
-			(acc, color, index) => {
-				acc[`color-${index + 1}`] = color.hex;
-				return acc;
-			},
-			{} as Record<string, string>,
-		);
-
-		return `module.exports = {
-  theme: {
-    extend: {
-      colors: ${JSON.stringify(colors, null, 8)}
-    }
-  }
-}`;
+		const colors = generatedColors.reduce<Record<string, string>>((acc, color, index) => {
+			acc[`color-${index + 1}`] = color.hex;
+			return acc;
+		}, {});
+		return `module.exports = { theme: { extend: { colors: ${JSON.stringify(colors, null, 2)} } } }`;
 	}, [generatedColors]);
 
 	const exportAsJSON = useCallback(() => {
-		return JSON.stringify(
-			{
-				palette: {
-					name: `Generated Palette ${new Date().toISOString()}`,
-					algorithm: generationAlgorithm,
-					harmony: currentHarmony?.type,
-					colors: generatedColors,
-					metadata: {
-						createdAt: new Date().toISOString(),
-						settings: {
-							colorCount,
-							hueRange,
-							saturationRange,
-							valueRange,
-						},
-					},
-				},
-			},
-			null,
-			2,
-		);
-	}, [
-		generatedColors,
-		generationAlgorithm,
-		currentHarmony,
-		colorCount,
-		hueRange,
-		saturationRange,
-		valueRange,
-	]);
+		return JSON.stringify({ palette: { algorithm: settings.generationAlgorithm, colors: generatedColors } }, null, 2);
+	}, [generatedColors, settings]);
 
-	// Copy to clipboard
-	const copyToClipboard = useCallback(
-		async (text: string) => {
-			try {
-				await navigator.clipboard.writeText(text);
-				showNotification("クリップボードにコピーしました");
-			} catch (err) {
-				console.error("Failed to copy to clipboard:", err);
-				showNotification("コピーに失敗しました");
-			}
-		},
-		[showNotification],
-	);
-
-	// Copy individual color
-	const copyColor = async (color: ColorInfo, format: "hex" | "rgb" | "hsl") => {
-		let text = "";
-		switch (format) {
-			case "hex":
-				text = color.hex;
-				break;
-			case "rgb":
-				text = `rgb(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b})`;
-				break;
-			case "hsl":
-				text = `hsl(${color.hsl.h}, ${color.hsl.s}%, ${color.hsl.l}%)`;
-				break;
+	const copyToClipboard = async (text: string) => {
+		try {
+			await navigator.clipboard.writeText(text);
+			showNotification("コピーしました");
+		} catch (err) {
+			showNotification("コピー失敗");
 		}
-		await copyToClipboard(text);
 	};
 
-	// Helper function to parse JSON palette data
-	const parseJsonPalette = useCallback((data: string): ColorInfo[] | null => {
-		const parsed = JSON.parse(data);
-
-		// Check for palette object format
-		if (parsed.palette) {
-			if (parsed.palette.colors) {
-				return parsed.palette.colors;
-			}
-		}
-
-		// Check for array format
-		if (Array.isArray(parsed)) {
-			if (parsed.length > 0) {
-				const colors: ColorInfo[] = [];
-				for (const item of parsed) {
-					if (typeof item === "string") {
-						if (item.startsWith("#")) {
-							const rgb = hexToRgb(item);
-							if (rgb) {
-								const hsv = { h: 0, s: 0, v: 0 };
-								const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
-								colors.push({
-									hex: item,
-									rgb,
-									hsv,
-									hsl,
-									accessibility: getAccessibilityInfo(rgb),
-								});
-							}
-						}
-					}
-				}
-				if (colors.length > 0) {
-					return colors;
-				}
-			}
-		}
-
-		return null;
-	}, []);
-
-	// Helper function to parse hex colors from string
-	const parseHexColors = useCallback((data: string): ColorInfo[] | null => {
-		const hexColors = data.match(/#[0-9a-fA-F]{6}/g);
-		if (!hexColors) {
-			return null;
-		}
-		if (hexColors.length === 0) {
-			return null;
-		}
-
-		const colors: ColorInfo[] = [];
-		for (const hex of hexColors) {
-			const rgb = hexToRgb(hex);
-			if (rgb) {
-				const hsv = { h: 0, s: 0, v: 0 };
-				const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
-				colors.push({
-					hex,
-					rgb,
-					hsv,
-					hsl,
-					accessibility: getAccessibilityInfo(rgb),
-				});
-			}
-		}
-
-		if (colors.length > 0) {
-			return colors;
-		}
-		return null;
-	}, []);
-
-	// Import palette from various formats
-	const importPalette = useCallback(
-		(data: string) => {
-			try {
-				const colors = parseJsonPalette(data);
-				if (colors) {
-					setGeneratedColors(colors);
-					showNotification("JSONパレットをインポートしました");
-					return;
-				}
-				showNotification("インポート形式が認識できません");
-			} catch {
-				const colors = parseHexColors(data);
-				if (colors) {
-					setGeneratedColors(colors);
-					showNotification(`${colors.length}色をインポートしました`);
-				} else {
-					showNotification("有効な色が見つかりません");
-				}
-			}
-		},
-		[showNotification, parseJsonPalette, parseHexColors],
-	);
-
-	// Handle file import
-	const handleFileImport = useCallback(
-		(event: React.ChangeEvent<HTMLInputElement>) => {
-			const file = event.target.files?.[0];
-			if (file) {
-				const reader = new FileReader();
-				reader.onload = (e) => {
-					const content = e.target?.result as string;
-					importPalette(content);
-				};
-				reader.readAsText(file);
-			}
-		},
-		[importPalette],
-	);
-
-	// Filter saved palettes
-	const filteredPalettes = savedPalettes.filter(
-		(palette) =>
-			palette.name.toLowerCase().includes(paletteSearch.toLowerCase()) ||
-			palette.tags.some((tag) =>
-				tag.toLowerCase().includes(paletteSearch.toLowerCase()),
-			),
-	);
-
-	// Handle keyboard shortcuts
-	useEffect(() => {
-		const handleToolShortcut = (event: CustomEvent) => {
-			switch (event.detail.key.toLowerCase()) {
-				case "g":
-					generateColors();
-					break;
-				case "s":
-					savePalette();
-					break;
-				case "e": {
-					const exportText =
-						exportFormat === "css"
-							? exportAsCSS()
-							: exportFormat === "tailwind"
-								? exportAsTailwind()
-								: exportAsJSON();
-					copyToClipboard(exportText);
-					break;
-				}
-				case "r":
-					setGeneratedColors([]);
-					setCurrentHarmony(null);
-					setSelectedColor(null);
-					break;
-				case "a":
-					setSettings((prev) => ({
-						...prev,
-						showAccessibility: !prev.showAccessibility,
-					}));
-					break;
-				case "h":
-					if (generatedColors.length > 0) {
-						setSelectedColor(generatedColors[0]);
-						setSettings((prev) => ({
-							...prev,
-							generationAlgorithm: "harmony",
-						}));
-						generateColors();
-					}
-					break;
-				case "m":
-					setShowPaletteManager(!showPaletteManager);
-					break;
-				case "i":
-					fileInputRef.current?.click();
-					break;
-			}
-		};
-
-		document.addEventListener(
-			"toolShortcut",
-			handleToolShortcut as EventListener,
-		);
-		return () =>
-			document.removeEventListener(
-				"toolShortcut",
-				handleToolShortcut as EventListener,
-			);
-	}, [
-		generateColors,
-		savePalette,
-		exportFormat,
-		exportAsCSS,
-		exportAsTailwind,
-		exportAsJSON,
-		copyToClipboard,
-		generatedColors,
-		showPaletteManager,
-	]);
-
-	// Load saved palettes from localStorage
 	useEffect(() => {
 		const saved = localStorage.getItem("color-palettes-v2");
 		if (saved) {
 			try {
 				setSavedPalettes(JSON.parse(saved));
-			} catch (err) {
-				console.error("Failed to load saved palettes:", err);
+			} catch (error) {
+				console.error(error);
 			}
 		}
 	}, []);
 
-	// Save palettes to localStorage
 	useEffect(() => {
 		localStorage.setItem("color-palettes-v2", JSON.stringify(savedPalettes));
 	}, [savedPalettes]);
 
-	// Design system classes
-	const CardStyle =
-		"rounded-xl bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)] p-4 space-y-4";
-	const Section_title = "neue-haas-grotesk-display text-xl text-main mb-4";
-	const Input_style =
-		"rounded-lg bg-main/10 p-2 text-main focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base";
-	const Button_style =
-		"bg-accent text-main px-4 py-2 border border-accent hover:bg-base hover:text-accent transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base";
-
 	return (
-		<ToolWrapper
-			toolName="Color Palette Generator"
-			description="高度なアルゴリズムとカラーハーモニー理論を使用したカラーパレット生成ツール.アクセシビリティチェック、パレット管理、多形式エクスポートに対応."
-			category="design"
-			keyboardShortcuts={keyboardShortcuts}
-			showPerformanceInfo={true}
-			enableOptimizations={true}
+		<RawDOMContainer
+			title="Color Palette Generator"
+			breadcrumbs={[
+				{ label: "Home", href: "/" },
+				{ label: "Tools", href: "/tools" },
+				{ label: "Color Palette Generator" },
+			]}
 		>
-			<OfflineSettingsManager
-				toolName="color-palette"
-				defaultSettings={defaultSettings}
-				settings={settings}
-				onSettingsChange={setSettings}
-				showControls={true}
-			>
-				{() => (
-					<div className="space-y-8">
-						{/* Notification */}
-						{notification && (
-							<div
-								className="bg-accent text-main p-3 border border-accent"
-								role="alert"
+			<div style={{ display: "flex", flexWrap: "wrap", gap: "20px" }}>
+				<div style={{ flex: "1 1 360px", display: "flex", flexDirection: "column", gap: "10px" }}>
+					<fieldset style={{ border: "1px solid #ccc", padding: "8px" }}>
+						<legend>Algorithm & Limits</legend>
+						<div style={{ display: "grid", gridTemplateColumns: "80px 1fr", gap: "8px", alignItems: "center" }}>
+							<label htmlFor="algo-select" style={{ whiteSpace: "nowrap" }}>Algorithm:</label>
+							<select
+								id="algo-select"
+								style={{ all: "revert", width: "100%", padding: "4px 8px", fontSize: "13px", boxSizing: "border-box" }}
+								value={settings.generationAlgorithm}
+								onChange={(e) =>
+									setSettings((prev) => ({
+										...prev,
+										generationAlgorithm: e.target.value as keyof typeof generationAlgorithms,
+									}))
+								}
 							>
-								{notification}
-							</div>
-						)}
+								{Object.entries(generationAlgorithms).map(([key, value]) => (
+									<option key={key} value={key}>
+										{value}
+									</option>
+								))}
+							</select>
+							<label htmlFor="count-input" style={{ whiteSpace: "nowrap" }}>Count:</label>
+							<input
+								id="count-input"
+								type="number"
+								min="1"
+								max="20"
+								style={{ all: "revert", width: "100%", padding: "4px 8px", fontSize: "13px", boxSizing: "border-box" }}
+								value={settings.colorCount}
+								onChange={(e) =>
+									setSettings((prev) => ({
+										...prev,
+										colorCount: Number(e.target.value),
+									}))
+								}
+							/>
+							<label htmlFor="sort-select" style={{ whiteSpace: "nowrap" }}>Sort By:</label>
+							<select
+								id="sort-select"
+								style={{ all: "revert", width: "100%", padding: "4px 8px", fontSize: "13px", boxSizing: "border-box" }}
+								value={settings.sortBy}
+								onChange={(e) =>
+									setSettings((prev) => ({
+										...prev,
+										sortBy: e.target.value as ColorPaletteSettings["sortBy"],
+									}))
+								}
+							>
+								<option value="none">None</option>
+								<option value="hue">Hue</option>
+								<option value="lightness">Lightness</option>
+								<option value="saturation">Saturation</option>
+							</select>
+						</div>
+					</fieldset>
 
-						{/* Hidden file input for import */}
-						<input
-							ref={fileInputRef}
-							type="file"
-							accept=".json,.css,.gpl,.ase"
-							onChange={handleFileImport}
-							aria-label="インポートするファイルを選択"
-							className="hidden"
-						/>
-
-						{/* Generation Algorithm Selection */}
-						<section className={CardStyle}>
-							<h3 className={Section_title}>Generation Algorithm</h3>
-							<div className="grid-system grid-1 sm:grid-2 gap-4">
-								<div className="space-y-2">
-									<label className="neue-haas-grotesk-display text-sm text-main">
-										Algorithm
-									</label>
-									<select
-										value={generationAlgorithm}
-										onChange={(e) =>
-											setSettings((prev) => ({
-												...prev,
-												generationAlgorithm: e.target
-													.value as keyof typeof generationAlgorithms,
-											}))
-										}
-										className={Input_style}
-										aria-label="Select generation algorithm"
-									>
-										{Object.entries(generationAlgorithms).map(
-											([key, label]) => (
-												<option key={key} value={key}>
-													{label}
-												</option>
-											),
-										)}
-									</select>
+					<fieldset style={{ border: "1px solid #ccc", padding: "8px" }}>
+						<legend>Color Range</legend>
+						<div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+							<div>
+								<div style={{ display: "flex", justifyContent: "space-between", marginBottom: "4px", fontSize: "12px" }}>
+									<span>Hue:</span>
+									<span>
+										{settings.hueRange.min} - {settings.hueRange.max}
+									</span>
 								</div>
-
-								{generationAlgorithm === "harmony" && (
-									<div className="space-y-2">
-										<label className="neue-haas-grotesk-display text-sm text-main">
-											Harmony Type
-										</label>
-										<select
-											value={harmonyType}
-											onChange={(e) =>
-												setSettings((prev) => ({
-													...prev,
-													harmonyType: e.target.value as ColorHarmony["type"],
-												}))
-											}
-											className={Input_style}
-											aria-label="Select harmony type"
-										>
-											<option value="monochromatic">Monochromatic</option>
-											<option value="analogous">Analogous</option>
-											<option value="complementary">Complementary</option>
-											<option value="triadic">Triadic</option>
-											<option value="tetradic">Tetradic</option>
-											<option value="split-complementary">
-												Split Complementary
-											</option>
-										</select>
-									</div>
-								)}
-							</div>
-
-							{currentHarmony && (
-								<div className="rounded-lg bg-main/10 p-3">
-									<h4 className="neue-haas-grotesk-display text-sm text-main mb-2">
-										Current Harmony: {currentHarmony.type}
-									</h4>
-									<p className="text-xs text-main">
-										{currentHarmony.description}
-									</p>
-								</div>
-							)}
-						</section>
-
-						{/* Color Range Settings */}
-						<section className={CardStyle}>
-							<h3 className={Section_title}>Color Range Settings</h3>
-
-							{/* Preset Buttons */}
-							<div className="space-y-4">
-								<h4 className="neue-haas-grotesk-display text-lg text-main">
-									Presets
-								</h4>
-								<div className="grid-system grid-2 xs:grid-3 sm:grid-5 gap-2">
-									{Object.keys(colorRangePresets).map((preset) => (
-										<button
-											type="button"
-											key={preset}
-											onClick={() =>
-												applyPreset(preset as keyof typeof colorRangePresets)
-											}
-											className="rounded-lg bg-main/10 px-3 py-2 text-sm hover:bg-main/20 transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base capitalize"
-										>
-											{preset}
-										</button>
-									))}
-								</div>
-							</div>
-
-							{/* Manual Range Controls */}
-							<div className="grid-system grid-1 sm:grid-3 gap-6">
-								{/* Hue Range */}
-								<div className="space-y-2">
-									<label className="neue-haas-grotesk-display text-sm text-main">
-										Hue Range (色相): {hueRange.min}° - {hueRange.max}°
-									</label>
-									<div className="space-y-2">
-										<label className="block">
-											<span className="text-xs text-main/70">最小値</span>
-											<input
-												type="range"
-												min="0"
-												max="360"
-												value={hueRange.min}
-												onChange={(e) =>
-													setSettings((prev) => ({
-														...prev,
-														hueRange: {
-															...prev.hueRange,
-															min: parseInt(e.target.value, 10),
-														},
-													}))
-												}
-												className="w-full"
-												id="hue-min"
-												data-testid="hue-min"
-											/>
-										</label>
-										<label className="block">
-											<span className="text-xs text-main/70">最大値</span>
-											<input
-												type="range"
-												min="0"
-												max="360"
-												value={hueRange.max}
-												onChange={(e) =>
-													setSettings((prev) => ({
-														...prev,
-														hueRange: {
-															...prev.hueRange,
-															max: parseInt(e.target.value, 10),
-														},
-													}))
-												}
-												className="w-full"
-												id="hue-max"
-												data-testid="hue-max"
-											/>
-										</label>
-									</div>
-								</div>
-
-								{/* Saturation Range */}
-								<div className="space-y-2">
-									<label className="neue-haas-grotesk-display text-sm text-main">
-										Saturation Range (彩度): {saturationRange.min}% -{" "}
-										{saturationRange.max}%
-									</label>
-									<div className="space-y-2">
-										<label className="block">
-											<span className="text-xs text-main/70">最小値</span>
-											<input
-												type="range"
-												min="0"
-												max="100"
-												value={saturationRange.min}
-												onChange={(e) =>
-													setSettings((prev) => ({
-														...prev,
-														saturationRange: {
-															...prev.saturationRange,
-															min: parseInt(e.target.value, 10),
-														},
-													}))
-												}
-												className="w-full"
-												id="saturation-min"
-												data-testid="saturation-min"
-											/>
-										</label>
-										<label className="block">
-											<span className="text-xs text-main/70">最大値</span>
-											<input
-												type="range"
-												min="0"
-												max="100"
-												value={saturationRange.max}
-												onChange={(e) =>
-													setSettings((prev) => ({
-														...prev,
-														saturationRange: {
-															...prev.saturationRange,
-															max: parseInt(e.target.value, 10),
-														},
-													}))
-												}
-												className="w-full"
-												id="saturation-max"
-												data-testid="saturation-max"
-											/>
-										</label>
-									</div>
-								</div>
-
-								{/* Value Range */}
-								<div className="space-y-2">
-									<label className="neue-haas-grotesk-display text-sm text-main">
-										Value Range (明度): {valueRange.min}% - {valueRange.max}%
-									</label>
-									<div className="space-y-2">
-										<label className="block">
-											<span className="text-xs text-main/70">最小値</span>
-											<input
-												type="range"
-												min="0"
-												max="100"
-												value={valueRange.min}
-												onChange={(e) =>
-													setSettings((prev) => ({
-														...prev,
-														valueRange: {
-															...prev.valueRange,
-															min: parseInt(e.target.value, 10),
-														},
-													}))
-												}
-												className="w-full"
-												id="value-min"
-											/>
-										</label>
-										<label className="block">
-											<span className="text-xs text-main/70">最大値</span>
-											<input
-												type="range"
-												min="0"
-												max="100"
-												value={valueRange.max}
-												onChange={(e) =>
-													setSettings((prev) => ({
-														...prev,
-														valueRange: {
-															...prev.valueRange,
-															max: parseInt(e.target.value, 10),
-														},
-													}))
-												}
-												className="w-full"
-												id="value-max"
-											/>
-										</label>
-									</div>
-								</div>
-							</div>
-
-							{/* Additional Settings */}
-							<div className="grid-system grid-1 sm:grid-3 gap-4">
-								<div className="space-y-2">
-									<label
-										htmlFor="color-count"
-										className="neue-haas-grotesk-display text-sm text-main"
-									>
-										Number of Colors: {colorCount}
-									</label>
+								<div style={{ display: "flex", gap: "4px", alignItems: "center" }}>
 									<input
-										id="color-count"
 										type="range"
-										min="1"
-										max="20"
-										value={colorCount}
+										min="0"
+										max="360"
+										value={settings.hueRange.min}
 										onChange={(e) =>
 											setSettings((prev) => ({
 												...prev,
-												colorCount: parseInt(e.target.value, 10),
+												hueRange: { ...prev.hueRange, min: Number(e.target.value) },
 											}))
 										}
-										className="w-full"
+										style={{ flex: 1 }}
+									/>
+									<input
+										type="range"
+										min="0"
+										max="360"
+										value={settings.hueRange.max}
+										onChange={(e) =>
+											setSettings((prev) => ({
+												...prev,
+												hueRange: { ...prev.hueRange, max: Number(e.target.value) },
+											}))
+										}
+										style={{ flex: 1 }}
 									/>
 								</div>
-
-								<div className="space-y-2">
-									<label className="neue-haas-grotesk-display text-sm text-main">
-										Sort By
-									</label>
-									<select
-										value={sortBy}
+							</div>
+							<div>
+								<div style={{ display: "flex", justifyContent: "space-between", marginBottom: "4px", fontSize: "12px" }}>
+									<span>Sat:</span>
+									<span>
+										{settings.saturationRange.min} - {settings.saturationRange.max}
+									</span>
+								</div>
+								<div style={{ display: "flex", gap: "4px", alignItems: "center" }}>
+									<input
+										type="range"
+										min="0"
+										max="100"
+										value={settings.saturationRange.min}
 										onChange={(e) =>
 											setSettings((prev) => ({
 												...prev,
-												sortBy: e.target.value as typeof sortBy,
+												saturationRange: { ...prev.saturationRange, min: Number(e.target.value) },
 											}))
 										}
-										className={Input_style}
-										aria-label="Sort colors by"
+										style={{ flex: 1 }}
+									/>
+									<input
+										type="range"
+										min="0"
+										max="100"
+										value={settings.saturationRange.max}
+										onChange={(e) =>
+											setSettings((prev) => ({
+												...prev,
+												saturationRange: { ...prev.saturationRange, max: Number(e.target.value) },
+											}))
+										}
+										style={{ flex: 1 }}
+									/>
+								</div>
+							</div>
+							<div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: "4px" }}>
+								{Object.keys(colorRangePresets).map((preset) => (
+									<button
+										key={preset}
+										type="button"
+										style={{ all: "revert", padding: "4px 8px", cursor: "pointer", fontSize: "12px", textAlign: "center" }}
+										onClick={() => applyPreset(preset as keyof typeof colorRangePresets)}
 									>
-										<option value="none">None</option>
-										<option value="hue">Hue</option>
-										<option value="lightness">Lightness</option>
-										<option value="saturation">Saturation</option>
-									</select>
-								</div>
-
-								<div className="space-y-2">
-									<label className="flex items-center space-x-2">
-										<input
-											type="checkbox"
-											checked={autoSave}
-											onChange={(e) =>
-												setSettings((prev) => ({
-													...prev,
-													autoSave: e.target.checked,
-												}))
-											}
-											className="focus:ring-2 focus:ring-accent"
-										/>
-										<span className="neue-haas-grotesk-display text-sm text-main">
-											Auto Save
-										</span>
-									</label>
-								</div>
+										{preset}
+									</button>
+								))}
 							</div>
-						</section>
+						</div>
+					</fieldset>
 
-						{/* Generation Controls */}
-						<section className={CardStyle}>
-							<div className="flex flex-wrap gap-4">
-								<AccessibleButton
-									onClick={generateColors}
-									variant="primary"
-									shortcut="G"
-									announceOnClick="新しいカラーパレットを生成しました"
-									aria-label="Generate new color palette"
-									data-testid="generate-colors"
-								>
-									Generate Colors
-								</AccessibleButton>
-								<AccessibleButton
-									onClick={() => savePalette()}
-									disabled={generatedColors.length === 0}
-									variant="secondary"
-									shortcut="S"
-									announceOnClick="パレットを保存しました"
-									aria-label="Save current palette"
-								>
-									Save Palette
-								</AccessibleButton>
-								<AccessibleButton
-									onClick={() =>
-										setSettings((prev) => ({
-											...prev,
-											showAccessibility: !prev.showAccessibility,
-										}))
-									}
-									variant="ghost"
-									shortcut="A"
-									announceOnClick={
-										showAccessibility
-											? "アクセシビリティ情報を非表示にしました"
-											: "アクセシビリティ情報を表示しました"
-									}
-									aria-label="Toggle accessibility information"
-								>
-									Accessibility
-								</AccessibleButton>
-								<AccessibleButton
-									onClick={() => setShowPaletteManager(!showPaletteManager)}
-									variant="ghost"
-									shortcut="M"
-									announceOnClick="パレット管理を開きました"
-									aria-label="Open palette manager"
-								>
-									Manage
-								</AccessibleButton>
-								<AccessibleButton
-									onClick={() => fileInputRef.current?.click()}
-									variant="ghost"
-									shortcut="I"
-									announceOnClick="パレットインポートを開始します"
-									aria-label="Import palette"
-								>
-									Import
-								</AccessibleButton>
-							</div>
-						</section>
-
-						{/* Generated Colors Display */}
-						{generatedColors.length > 0 && (
-							<section className={CardStyle}>
-								<h3 className={Section_title}>Generated Palette</h3>
-								<div className="grid-system grid-1 xs:grid-2 sm:grid-3 md:grid-5 gap-4">
-									{generatedColors.map((color, index) => (
+					<fieldset style={{ border: "1px solid #ccc", padding: "8px" }}>
+						<legend>Saved Palettes</legend>
+						<div style={{ maxHeight: "160px", overflowY: "auto", fontSize: "12px" }}>
+							{savedPalettes.length === 0
+								? "No saved palettes."
+								: savedPalettes.map((palette) => (
 										<div
-											key={index}
-											className={`space-y-2 ${
-												selectedColor === color ? "ring-2 ring-accent" : ""
-											}`}
-											role="button"
-											tabIndex={0}
-											aria-label={`Color ${index + 1}: ${color.hex}`}
-											data-testid="color-item"
-											onClick={() => setSelectedColor(color)}
-											onKeyDown={(e) => {
-												if (e.key === "Enter" || e.key === " ") {
-													e.preventDefault();
-													setSelectedColor(color);
-												}
+											key={palette.id}
+											style={{
+												display: "flex",
+												justifyContent: "space-between",
+												gap: "8px",
+												marginBottom: "4px",
+												borderBottom: "1px solid #eee",
+												paddingBottom: "4px",
 											}}
 										>
-											<div
-												className="w-full h-20 rounded-lg cursor-pointer ring-2 ring-main/20 hover:ring-main/40 transition-all"
-												style={{ backgroundColor: color.hex }}
-												onClick={() => copyColor(color, "hex")}
-												onKeyDown={(e) => {
-													if (e.key === "Enter" || e.key === " ") {
-														e.preventDefault();
-														copyColor(color, "hex");
+											<span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+												{palette.name} ({palette.colors.length}c)
+											</span>
+											<div style={{ display: "flex", gap: "4px", flexShrink: 0 }}>
+												<button
+													type="button"
+													style={{ all: "revert", padding: "4px 8px", cursor: "pointer", fontSize: "12px" }}
+													onClick={() => setGeneratedColors(palette.colors)}
+												>
+													Load
+												</button>
+												<button
+													type="button"
+													style={{ all: "revert", padding: "4px 8px", cursor: "pointer", fontSize: "12px" }}
+													onClick={() =>
+														setSavedPalettes((prev) => prev.filter((saved) => saved.id !== palette.id))
 													}
-												}}
-												title={`Click to copy ${color.hex}`}
-											/>
-											<div className="text-xs space-y-1">
-												<button
-													type="button"
-													onClick={() => copyColor(color, "hex")}
-													className="block w-full text-left hover:text-accent focus:outline-none focus:text-accent"
-													title="Click to copy HEX value"
-													data-testid="copy-hex"
 												>
-													HEX: {color.hex}
+													Del
 												</button>
-												<button
-													type="button"
-													onClick={() => copyColor(color, "rgb")}
-													className="block w-full text-left hover:text-accent focus:outline-none focus:text-accent"
-													title="Click to copy RGB value"
-												>
-													RGB: {color.rgb.r}, {color.rgb.g}, {color.rgb.b}
-												</button>
-												<button
-													type="button"
-													onClick={() => copyColor(color, "hsl")}
-													className="block w-full text-left hover:text-accent focus:outline-none focus:text-accent"
-													title="Click to copy HSL value"
-												>
-													HSL: {color.hsl.h}, {color.hsl.s}%, {color.hsl.l}%
-												</button>
+											</div>
+										</div>
+									))}
+						</div>
+					</fieldset>
+				</div>
 
-												{/* Enhanced Accessibility Information */}
-												{showAccessibility && color.accessibility && (
-													<div className="pt-2 border-t border-main/20">
-														<div className="text-xs space-y-1">
-															<div className="flex justify-between">
-																<span>vs White:</span>
-																<span
-																	className={
-																		color.accessibility.readableOnWhite
-																			? "text-green-600"
-																			: "text-red-600"
-																	}
-																>
-																	{color.accessibility.contrastWithWhite.toFixed(
-																		2,
-																	)}
-																</span>
-															</div>
-															<div className="flex justify-between">
-																<span>vs Black:</span>
-																<span
-																	className={
-																		color.accessibility.readableOnBlack
-																			? "text-green-600"
-																			: "text-red-600"
-																	}
-																>
-																	{color.accessibility.contrastWithBlack.toFixed(
-																		2,
-																	)}
-																</span>
-															</div>
-															<div className="flex justify-between">
-																<span>WCAG AA:</span>
-																<span
-																	className={
-																		color.accessibility.wcagAA
-																			? "text-green-600"
-																			: "text-red-600"
-																	}
-																>
-																	{color.accessibility.wcagAA ? "✓" : "✗"}
-																</span>
-															</div>
-															<div className="flex justify-between">
-																<span>WCAG AAA:</span>
-																<span
-																	className={
-																		color.accessibility.wcagAAA
-																			? "text-green-600"
-																			: "text-red-600"
-																	}
-																>
-																	{color.accessibility.wcagAAA ? "✓" : "✗"}
-																</span>
-															</div>
-															{enableColorBlindCheck && (
-																<div className="flex justify-between">
-																	<span>Color Blind Safe:</span>
-																	<span
-																		className={
-																			color.accessibility.colorBlindSafe
-																				? "text-green-600"
-																				: "text-yellow-600"
-																		}
-																	>
-																		{color.accessibility.colorBlindSafe
-																			? "✓"
-																			: "?"}
-																	</span>
-																</div>
-															)}
-														</div>
-													</div>
-												)}
+				<div style={{ flex: "1 1 360px", display: "flex", flexDirection: "column", gap: "10px" }}>
+					<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px" }}>
+						<button type="button" onClick={generateColors} style={{ all: "revert", padding: "4px 8px", cursor: "pointer", fontSize: "13px" }}>
+							Generate Colors
+						</button>
+						<button type="button" onClick={() => savePalette()} style={{ all: "revert", padding: "4px 8px", cursor: "pointer", fontSize: "13px" }}>
+							Save Palette
+						</button>
+					</div>
+
+					<fieldset style={{ border: "1px solid #ccc", padding: "8px" }}>
+						<legend>Generated Palette</legend>
+						{generatedColors.length === 0 ? (
+							<div style={{ padding: "8px", textAlign: "center", color: "#999", fontSize: "12px" }}>
+								Click "Generate Colors" to begin.
+							</div>
+						) : (
+							<>
+								<div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(100px, 1fr))", gap: "6px" }}>
+									{generatedColors.map((color) => (
+										<div
+											key={color.hex}
+											style={{
+												display: "flex",
+												flexDirection: "column",
+												border: "1px solid #ccc",
+											}}
+										>
+											<div style={{ backgroundColor: color.hex, height: "80px", width: "100%" }} />
+											<div style={{ padding: "4px", fontSize: "11px", textAlign: "center" }}>
+												<div style={{ fontFamily: "monospace", marginBottom: "2px" }}>{color.hex}</div>
+												<button
+													type="button"
+													onClick={() => copyToClipboard(color.hex)}
+													style={{ all: "revert", width: "100%", padding: "4px 8px", cursor: "pointer", fontSize: "11px" }}
+												>
+													Copy
+												</button>
 											</div>
 										</div>
 									))}
 								</div>
-							</section>
-						)}
-
-						{/* Export Section */}
-						{generatedColors.length > 0 && (
-							<section className={CardStyle}>
-								<h3 className={Section_title}>Export Palette</h3>
-								<div className="space-y-4">
-									<div className="flex flex-wrap gap-4">
-										<select
-											value={exportFormat}
-											onChange={(e) =>
-												setSettings((prev) => ({
-													...prev,
-													exportFormat: e.target.value as typeof exportFormat,
-												}))
-											}
-											className={Input_style}
-											aria-label="Select export format"
-										>
-											<option value="css">CSS Variables</option>
-											<option value="tailwind">Tailwind Config</option>
-											<option value="json">JSON</option>
-										</select>
-										<button
-											type="button"
-											onClick={() => {
-												const exportText =
-													exportFormat === "css"
-														? exportAsCSS()
-														: exportFormat === "tailwind"
-															? exportAsTailwind()
-															: exportAsJSON();
-												copyToClipboard(exportText);
-											}}
-											className={Button_style}
-											aria-label="Copy export code to clipboard"
-											data-testid="export-copy"
-										>
-											Copy (E)
-										</button>
-									</div>
-
-									<div className="rounded-lg bg-main/10 p-4 overflow-x-auto">
-										<pre className="text-xs whitespace-pre-wrap">
-											{exportFormat === "css"
-												? exportAsCSS()
-												: exportFormat === "tailwind"
-													? exportAsTailwind()
-													: exportAsJSON()}
-										</pre>
-									</div>
-								</div>
-							</section>
-						)}
-
-						{/* Import Section */}
-						<section className={CardStyle}>
-							<h3 className={Section_title}>Import Palette</h3>
-							<div className="space-y-4">
-								<textarea
-									value={importedPalette}
-									onChange={(e) => setImportedPalette(e.target.value)}
-									placeholder="Paste JSON palette data, hex colors, or other supported formats..."
-									className={`${Input_style} w-full h-24 resize-none`}
-									aria-label="Import palette data"
-								/>
-								<div className="flex gap-4">
-									<button
-										type="button"
-										onClick={() => {
-											if (importedPalette.trim()) {
-												importPalette(importedPalette);
-												setImportedPalette("");
-											}
-										}}
-										disabled={!importedPalette.trim()}
-										className={Button_style}
-									>
-										Import from Text
-									</button>
-									<button
-										type="button"
-										onClick={() => fileInputRef.current?.click()}
-										className={Button_style}
-									>
-										Import from File
-									</button>
-								</div>
-							</div>
-						</section>
-
-						{/* Palette Manager */}
-						{showPaletteManager && (
-							<section className={CardStyle}>
-								<h3 className={Section_title}>
-									Saved Palettes ({savedPalettes.length})
-								</h3>
-
-								{savedPalettes.length > 0 && (
-									<div className="space-y-4">
-										<input
-											type="text"
-											value={paletteSearch}
-											onChange={(e) => setPaletteSearch(e.target.value)}
-											placeholder="Search palettes..."
-											className={Input_style}
-											aria-label="Search saved palettes"
-										/>
-
-										<div className="space-y-4 max-h-96 overflow-y-auto">
-											{filteredPalettes.map((palette) => (
-												<div
-													key={palette.id}
-													className="rounded-lg bg-main/10 p-3"
-												>
-													<div className="flex justify-between items-start mb-2">
-														<div>
-															<span className="text-sm font-medium">
-																{palette.name}
-															</span>
-															<div className="text-xs text-main opacity-70">
-																{new Date(
-																	palette.createdAt,
-																).toLocaleDateString()}{" "}
-																• {palette.colors.length} colors
-															</div>
-															{palette.tags.length > 0 && (
-																<div className="flex gap-1 mt-1">
-																	{palette.tags.map((tag, index) => (
-																		<span
-																			key={index}
-																			className="text-xs rounded-lg bg-main/10 px-2 py-1"
-																		>
-																			{tag}
-																		</span>
-																	))}
-																</div>
-															)}
-														</div>
-														<div className="space-x-2">
-															<button
-																type="button"
-																onClick={() => loadPalette(palette)}
-																className="text-xs bg-accent text-main px-2 py-1 hover:bg-base hover:text-accent border border-accent transition-colors focus:outline-none focus:ring-1 focus:ring-accent"
-															>
-																Load
-															</button>
-															<button
-																type="button"
-																onClick={() => deletePalette(palette.id)}
-																className="text-xs rounded-lg bg-main/10 px-2 py-1 hover:bg-main/20 transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
-															>
-																Delete
-															</button>
-														</div>
-													</div>
-													<div className="flex gap-1">
-														{palette.colors.map((color, colorIndex) => (
-															<div
-																key={colorIndex}
-																className="w-8 h-8 rounded cursor-pointer ring-2 ring-main/20 hover:ring-main/40 transition-all"
-																style={{ backgroundColor: color.hex }}
-																onClick={() => copyColor(color, "hex")}
-																title={color.hex}
-															/>
-														))}
-													</div>
-												</div>
-											))}
-										</div>
+								{notification && (
+									<div style={{ marginTop: "8px", padding: "4px 8px", background: "#f5f5f5", border: "1px solid #eee", fontSize: "12px", textAlign: "center" }}>
+										{notification}
 									</div>
 								)}
-
-								{savedPalettes.length === 0 && (
-									<p className="text-sm text-main opacity-70">
-										No saved palettes yet. Generate and save some palettes to
-										see them here.
-									</p>
-								)}
-							</section>
+							</>
 						)}
-					</div>
-				)}
-			</OfflineSettingsManager>
-		</ToolWrapper>
+					</fieldset>
+
+					<fieldset style={{ border: "1px solid #ccc", padding: "8px" }}>
+						<legend>Export</legend>
+						<div style={{ display: "flex", gap: "6px", marginBottom: "6px" }}>
+							<select
+								style={{ all: "revert", flex: 1, padding: "4px 8px", fontSize: "13px" }}
+								value={settings.exportFormat}
+								onChange={(e) =>
+									setSettings((prev) => ({
+										...prev,
+										exportFormat: e.target.value as ColorPaletteSettings["exportFormat"],
+									}))
+								}
+							>
+								<option value="css">CSS Variables</option>
+								<option value="tailwind">Tailwind Config</option>
+								<option value="json">JSON</option>
+							</select>
+							<button
+								type="button"
+								style={{ all: "revert", padding: "4px 8px", cursor: "pointer", fontSize: "13px" }}
+								onClick={() => {
+									const txt =
+										settings.exportFormat === "css"
+											? exportAsCSS()
+											: settings.exportFormat === "tailwind"
+												? exportAsTailwind()
+												: exportAsJSON();
+									copyToClipboard(txt);
+								}}
+							>
+								Copy
+							</button>
+						</div>
+						<textarea
+							readOnly
+							style={{
+								all: "revert",
+								width: "100%",
+								height: "100px",
+								fontFamily: "monospace",
+								fontSize: "11px",
+								padding: "4px 8px",
+								boxSizing: "border-box",
+								border: "1px solid #eee",
+							}}
+							value={
+								settings.exportFormat === "css"
+									? exportAsCSS()
+									: settings.exportFormat === "tailwind"
+										? exportAsTailwind()
+										: exportAsJSON()
+							}
+						/>
+					</fieldset>
+				</div>
+			</div>
+		</RawDOMContainer>
 	);
 }

--- a/src/app/tools/color-palette/page.tsx
+++ b/src/app/tools/color-palette/page.tsx
@@ -1,4 +1,3 @@
-import { Breadcrumbs } from "@/components/ui/Breadcrumbs";
 import ColorPaletteGenerator from "./components/ColorPaletteGenerator";
 
 export const metadata = {
@@ -27,51 +26,5 @@ export const metadata = {
 };
 
 export default function ColorPalettePage() {
-	return (
-		<>
-			<div className="relative min-h-screen bg-base text-main">
-				<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
-					<div className="container-system">
-						<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">
-							<Breadcrumbs
-								items={[
-									{ label: "Home", href: "/" },
-									{ label: "Tools", href: "/tools" },
-									{ label: "Color Palette Generator", isCurrent: true },
-								]}
-								className="pt-4"
-							/>
-
-							<section className="space-y-6">
-								<ColorPaletteGenerator />
-							</section>
-						</div>
-					</div>
-				</main>
-			</div>
-
-			{/* Structured Data */}
-			<script type="application/ld+json">
-				{JSON.stringify({
-					"@context": "https://schema.org",
-					"@type": "WebApplication",
-					name: "Color Palette Generator",
-					description: "色域を指定してランダムにカラーパレットを生成",
-					url: "https://yusuke-kim.com/tools/color-palette",
-					applicationCategory: "DesignApplication",
-					operatingSystem: "Web Browser",
-					author: {
-						"@type": "Person",
-						name: "木村友亮",
-						alternateName: "samuido",
-					},
-					offers: {
-						"@type": "Offer",
-						price: "0",
-						priceCurrency: "JPY",
-					},
-				})}
-			</script>
-		</>
-	);
+	return <ColorPaletteGenerator />;
 }

--- a/src/app/tools/components/AccessibleButton.tsx
+++ b/src/app/tools/components/AccessibleButton.tsx
@@ -19,7 +19,6 @@ interface AccessibleButtonProps
 	size?: "sm" | "md" | "lg";
 	loading?: boolean;
 	loadingText?: string;
-	shortcut?: string;
 	announceOnClick?: string;
 	ensureMinimumSize?: boolean;
 	"data-testid"?: string;
@@ -33,7 +32,6 @@ const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
 			size = "md",
 			loading = false,
 			loadingText = "読み込み中...",
-			shortcut,
 			announceOnClick,
 			ensureMinimumSize = true,
 			className = "",
@@ -69,7 +67,7 @@ const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
 		const baseStyles = `
       inline-flex items-center justify-center
       font-medium transition-colors duration-200
-      focus:outline-none focus:ring-2 focus:ring-offset-2
+      focus:outline-none focus:ring-1
       disabled:opacity-50 disabled:cursor-not-allowed
       ${state.prefersReducedMotion ? "" : "transition-all duration-200"}
     `;
@@ -79,22 +77,22 @@ const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
 			primary: `
         bg-accent text-main border border-accent
         hover:bg-base hover:text-accent
-        focus:ring-accent focus:ring-offset-base
+        focus:ring-accent focus:border-accent
       `,
 			secondary: `
         bg-base text-main border border-main
         hover:bg-base
-        focus:ring-main focus:ring-offset-base
+        focus:ring-main focus:border-main
       `,
 			danger: `
         bg-red-600 text-white border border-red-600
         hover:bg-red-700
-        focus:ring-red-500 focus:ring-offset-base
+        focus:ring-red-500 focus:border-red-500
       `,
 			ghost: `
         bg-transparent text-main border border-transparent
         hover:bg-base hover:border-main
-        focus:ring-main focus:ring-offset-base
+        focus:ring-main focus:border-main
       `,
 		};
 
@@ -129,7 +127,6 @@ const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
 				disabled={disabled || loading}
 				aria-label={loading ? loadingText : accessibleLabel}
 				aria-busy={loading}
-				data-shortcut={shortcut}
 				{...props}
 			>
 				{loading ? (
@@ -160,14 +157,6 @@ const AccessibleButton = forwardRef<HTMLButtonElement, AccessibleButtonProps>(
 				) : (
 					<span className="flex items-center space-x-2">
 						<span>{children}</span>
-						{shortcut && (
-							<kbd
-								className="text-xs bg-base bg-opacity-20 border border-current px-1.5 py-0.5 rounded"
-								aria-label={`ショートカット: ${shortcut}`}
-							>
-								{shortcut}
-							</kbd>
-						)}
 					</span>
 				)}
 			</button>

--- a/src/app/tools/components/AccessibleInput.tsx
+++ b/src/app/tools/components/AccessibleInput.tsx
@@ -106,11 +106,11 @@ const AccessibleInput = forwardRef<
 		// Base styles with accessibility considerations
 		const baseInputStyles = `
       w-full bg-base border text-main
-      focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base
+      focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent
       disabled:opacity-50 disabled:cursor-not-allowed
       ${state.prefersReducedMotion ? "" : "transition-all duration-200"}
       ${error ? "border-red-500" : "border-main/20"}
-      ${isFocused ? "ring-2 ring-accent ring-offset-2 ring-offset-base" : ""}
+      ${isFocused ? "ring-1 ring-accent border-accent" : ""}
     `;
 
 		// Variant styles

--- a/src/app/tools/components/AccessibleSelect.tsx
+++ b/src/app/tools/components/AccessibleSelect.tsx
@@ -80,12 +80,12 @@ const AccessibleSelect = forwardRef<HTMLSelectElement, AccessibleSelectProps>(
 		// Base styles with accessibility considerations
 		const baseSelectStyles = `
       w-full bg-base border text-main
-      focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base
+      focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent
       disabled:opacity-50 disabled:cursor-not-allowed
       appearance-none cursor-pointer
       ${state.prefersReducedMotion ? "" : "transition-all duration-200"}
       ${error ? "border-red-500" : "border-main/20"}
-      ${isFocused ? "ring-2 ring-accent ring-offset-2 ring-offset-base" : ""}
+      ${isFocused ? "ring-1 ring-accent border-accent" : ""}
     `;
 
 		// Variant styles

--- a/src/app/tools/components/RawDOMContainer.tsx
+++ b/src/app/tools/components/RawDOMContainer.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React from 'react';
+
+export interface BreadcrumbItem {
+	label: string;
+	href?: string;
+	isCurrent?: boolean;
+}
+
+interface RawDOMContainerProps {
+	title: string;
+	breadcrumbs: BreadcrumbItem[];
+	children: React.ReactNode;
+}
+
+export function RawDOMContainer({ title, breadcrumbs, children }: RawDOMContainerProps) {
+	return (
+		<div style={{ position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh", zIndex: 9999, backgroundColor: "#ffffff", color: "#000000", fontFamily: "sans-serif", overflowY: "auto", padding: "2rem", boxSizing: "border-box" }}>
+			<div style={{ maxWidth: "900px", margin: "0 auto", paddingBottom: "4rem" }}>
+				
+				<nav style={{ fontSize: "0.85rem", marginBottom: "1rem", color: "#666" }}>
+					{breadcrumbs.map((item, index) => (
+						<React.Fragment key={index}>
+							{item.href ? (
+								<a href={item.href} style={{ color: "#0066cc", textDecoration: "none" }}>{item.label}</a>
+							) : (
+								<span style={{ color: "#000" }}>{item.label}</span>
+							)}
+							{index < breadcrumbs.length - 1 && (
+								<span style={{ margin: "0 8px" }}>/</span>
+							)}
+						</React.Fragment>
+					))}
+				</nav>
+
+				<h1 style={{ borderBottom: "1px solid #ccc", paddingBottom: "10px", marginBottom: "20px", fontSize: "1.5rem", fontWeight: "normal" }}>
+					{title}
+				</h1>
+
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/src/app/tools/components/ToolWrapper.tsx
+++ b/src/app/tools/components/ToolWrapper.tsx
@@ -10,10 +10,6 @@ interface ToolWrapperProps {
 	toolName: string;
 	description: string;
 	category: string;
-	keyboardShortcuts?: Array<{
-		key: string;
-		description: string;
-	}>;
 	showPerformanceInfo?: boolean;
 	enableOptimizations?: boolean;
 }
@@ -23,7 +19,6 @@ export default function ToolWrapper({
 	toolName,
 	description,
 	category,
-	keyboardShortcuts = [],
 	showPerformanceInfo = false,
 	enableOptimizations = true,
 }: ToolWrapperProps) {
@@ -61,7 +56,7 @@ export default function ToolWrapper({
 		);
 	}, [toolName, announce]);
 
-	// Enhanced keyboard shortcuts handler with accessibility
+	// Enhanced accessibility shortcuts handler
 	useEffect(() => {
 		const handleKeyPress = (event: KeyboardEvent) => {
 			// Only handle shortcuts when not in input fields
@@ -95,19 +90,6 @@ export default function ToolWrapper({
 				return;
 			}
 
-			keyboardShortcuts.forEach((shortcut) => {
-				if (event.key.toLowerCase() === shortcut.key.toLowerCase()) {
-					event.preventDefault();
-					// Announce shortcut activation
-					announce(`${shortcut.description}を実行しました`);
-					// Trigger custom event for tool-specific shortcuts
-					const customEvent = new CustomEvent("toolShortcut", {
-						detail: { key: shortcut.key, description: shortcut.description },
-					});
-					document.dispatchEvent(customEvent);
-				}
-			});
-
 			// Global shortcuts
 			if (event.key === "Escape") {
 				// Focus back to main content
@@ -122,14 +104,13 @@ export default function ToolWrapper({
 		document.addEventListener("keydown", handleKeyPress);
 		return () => document.removeEventListener("keydown", handleKeyPress);
 	}, [
-		keyboardShortcuts,
 		showAccessibilityInfo,
 		announce,
 		runAccessibilityChecks,
 	]);
 
 	return (
-		<div className="min-h-screen bg-base text-main scrollbar-auto-stable">
+		<div className="min-h-screen text-main scrollbar-auto-stable">
 			<main className="py-10" tabIndex={-1} ref={containerRef}>
 				<div className="container-system">
 					<div className="mx-auto w-full max-w-6xl space-y-10 px-4 sm:px-6 lg:px-8">
@@ -154,68 +135,6 @@ export default function ToolWrapper({
 							</div>
 						</header>
 
-						{/* Enhanced Keyboard Shortcuts Help */}
-						{keyboardShortcuts.length > 0 && (
-							<section
-								aria-labelledby="shortcuts-heading"
-								className="rounded-2xl bg-base/75 backdrop-blur-md shadow-[0_24px_60px_rgba(0,0,0,0.35)] p-6"
-							>
-								<h2
-									id="shortcuts-heading"
-									className="neue-haas-grotesk-display text-lg text-main mb-4"
-								>
-									Keyboard Shortcuts
-								</h2>
-								<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-									{keyboardShortcuts.map((shortcut, index) => (
-										<div key={index} className="flex items-center space-x-2">
-											<kbd
-												className="text-xs rounded bg-main/10 px-2 py-1 min-w-[2rem] text-center text-main"
-												aria-label={`キー ${shortcut.key}`}
-											>
-												{shortcut.key}
-											</kbd>
-											<span className="noto-sans-jp-light text-xs text-main/80">
-												{shortcut.description}
-											</span>
-										</div>
-									))}
-									<div className="flex items-center space-x-2">
-										<kbd
-											className="text-xs rounded bg-main/10 px-2 py-1 min-w-[2rem] text-center text-main"
-											aria-label="エスケープキー"
-										>
-											Esc
-										</kbd>
-										<span className="noto-sans-jp-light text-xs text-main/80">
-											メインコンテンツにフォーカス
-										</span>
-									</div>
-									<div className="flex items-center space-x-2">
-										<kbd
-											className="text-xs rounded bg-main/10 px-2 py-1 min-w-[2rem] text-center text-main"
-											aria-label="シフト + クエスチョンマーク"
-										>
-											?
-										</kbd>
-										<span className="noto-sans-jp-light text-xs text-main/80">
-											アクセシビリティ情報表示
-										</span>
-									</div>
-									<div className="flex items-center space-x-2">
-										<kbd
-											className="text-xs rounded bg-main/10 px-2 py-1 min-w-[2rem] text-center text-main"
-											aria-label="コントロール + A"
-										>
-											Ctrl+A
-										</kbd>
-										<span className="noto-sans-jp-light text-xs text-main/80">
-											アクセシビリティチェック
-										</span>
-									</div>
-								</div>
-							</section>
-						)}
 
 						{/* Accessibility Information Panel */}
 						{showAccessibilityInfo && (
@@ -298,7 +217,7 @@ export default function ToolWrapper({
 							<div
 								role="application"
 								aria-label={`${toolName} tool`}
-								className={`focus-within:ring-2 focus-within:ring-accent focus-within:ring-offset-2 focus-within:ring-offset-base ${
+								className={`${
 									state.prefersReducedMotion
 										? ""
 										: "transition-all duration-200"
@@ -314,7 +233,7 @@ export default function ToolWrapper({
 							<div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
 								<Link
 									href="/tools"
-									className="rounded-2xl bg-base/75 backdrop-blur-md shadow-[0_24px_60px_rgba(0,0,0,0.35)] text-center p-4 flex items-center justify-center transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
+									className="rounded-2xl bg-base/75 backdrop-blur-md shadow-[0_24px_60px_rgba(0,0,0,0.35)] text-center p-4 flex items-center justify-center transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent"
 								>
 									<span className="noto-sans-jp-regular text-base leading-snug text-main">
 										← Tools
@@ -322,7 +241,7 @@ export default function ToolWrapper({
 								</Link>
 								<Link
 									href="/"
-									className="rounded-2xl bg-base/75 backdrop-blur-md shadow-[0_24px_60px_rgba(0,0,0,0.35)] text-center p-4 flex items-center justify-center transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
+									className="rounded-2xl bg-base/75 backdrop-blur-md shadow-[0_24px_60px_rgba(0,0,0,0.35)] text-center p-4 flex items-center justify-center transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent"
 								>
 									<span className="noto-sans-jp-regular text-base leading-snug text-main">
 										← Home

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -12,11 +12,8 @@ import {
 	Zap,
 } from "lucide-react";
 import Link from "next/link";
-import HomeBackground from "@/components/HomeBackground";
 import { Breadcrumbs } from "@/components/ui/Breadcrumbs";
-
-const CARD_SURFACE =
-	"group relative flex h-full flex-col overflow-hidden rounded-2xl bg-base/75 backdrop-blur-md shadow-[0_24px_60px_rgba(0,0,0,0.35)] transition-transform duration-300 hover:-translate-y-0.5";
+import GlowCard from "@/components/ui/GlowCard";
 
 interface Tool {
 	id: string;
@@ -138,44 +135,10 @@ const tools: Tool[] = [
 	},
 ];
 
-const categories = [
-	{ key: "all", label: "すべて", count: tools.length },
-	{
-		key: "ゲーム",
-		label: "ゲーム",
-		count: tools.filter((t) => t.category === "ゲーム").length,
-	},
-	{
-		key: "生産性",
-		label: "生産性",
-		count: tools.filter((t) => t.category === "生産性").length,
-	},
-	{
-		key: "ユーティリティ",
-		label: "ユーティリティ",
-		count: tools.filter((t) => t.category === "ユーティリティ").length,
-	},
-	{
-		key: "デザイン",
-		label: "デザイン",
-		count: tools.filter((t) => t.category === "デザイン").length,
-	},
-	{
-		key: "開発",
-		label: "開発",
-		count: tools.filter((t) => t.category === "開発").length,
-	},
-	{
-		key: "ビジネス",
-		label: "ビジネス",
-		count: tools.filter((t) => t.category === "ビジネス").length,
-	},
-];
 
 export default function ToolsPage() {
 	return (
-		<div className="relative min-h-screen bg-base text-main">
-			<HomeBackground />
+		<div className="relative min-h-screen text-main">
 			<main
 				id="main-content"
 				className="relative z-10 min-h-screen py-10"
@@ -200,27 +163,6 @@ export default function ToolsPage() {
 							</p>
 						</header>
 
-						{/* Categories */}
-						<section className="space-y-6">
-							<h2 className="neue-haas-grotesk-display text-3xl text-main">
-								Categories
-							</h2>
-							<div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7 gap-4">
-								{categories.map((category) => (
-									<div
-										key={category.key}
-										className="rounded-xl bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)] p-4 text-center"
-									>
-										<div className="neue-haas-grotesk-display text-2xl text-accent mb-1">
-											{category.count}
-										</div>
-										<div className="noto-sans-jp-light text-xs text-main/80">
-											{category.label}
-										</div>
-									</div>
-								))}
-							</div>
-						</section>
 
 						{/* Tools Grid */}
 						<section className="space-y-6">
@@ -234,30 +176,28 @@ export default function ToolsPage() {
 										<Link
 											key={tool.id}
 											href={tool.href}
-											className="block focus:outline-none"
+											className="block focus:outline-none group h-full"
 										>
-											<article
-												className={`${CARD_SURFACE} focus:outline-none focus:ring-2 focus:ring-accent/60 focus:ring-offset-2 focus:ring-offset-base`}
-											>
-												<div className="flex flex-col gap-4 p-6">
-													<div className="flex items-start justify-between">
-														<div className="rounded-xl bg-main/10 p-3">
-															<Icon className="w-6 h-6 text-accent" />
-														</div>
-														<span className="noto-sans-jp-light rounded-full bg-main/10 px-3 py-1 text-[0.75rem] text-main">
-															{tool.category}
-														</span>
-													</div>
+											<GlowCard className="bg-base/30 backdrop-blur h-full flex flex-col">
+												<div className="flex flex-col p-6 h-full">
 													<div className="flex flex-1 flex-col gap-3">
-														<h3 className="neue-haas-grotesk-display text-lg leading-snug text-main sm:text-xl">
-															{tool.title}
-														</h3>
-														<p className="noto-sans-jp-light text-sm leading-relaxed text-main/80">
+														<div className="flex items-start justify-between gap-2">
+															<div className="flex items-center gap-3">
+																<Icon className="w-6 h-6 text-accent group-hover:scale-110 transition-transform duration-300 shrink-0" />
+																<h3 className="neue-haas-grotesk-display text-lg leading-snug text-main sm:text-xl group-hover:text-accent transition-colors">
+																	{tool.title}
+																</h3>
+															</div>
+															<span className="noto-sans-jp-light rounded-full bg-main/10 px-3 py-1 text-[0.75rem] text-main shrink-0">
+																{tool.category}
+															</span>
+														</div>
+														<p className="noto-sans-jp-light text-sm leading-relaxed text-main/80 mt-1">
 															{tool.description}
 														</p>
 													</div>
 												</div>
-											</article>
+											</GlowCard>
 										</Link>
 									);
 								})}

--- a/src/app/tools/pi-game/page.tsx
+++ b/src/app/tools/pi-game/page.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 
 export default function PiGamePage() {
 	return (
-		<div className="relative min-h-screen bg-base text-main">
+		<div className="relative min-h-screen text-main">
 			<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
 				<div className="container-system">
 					<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/tools/qr-generator/components/QRCodeGenerator.tsx
+++ b/src/app/tools/qr-generator/components/QRCodeGenerator.tsx
@@ -1,651 +1,338 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import AccessibleButton from "../../components/AccessibleButton";
-import AccessibleSelect from "../../components/AccessibleSelect";
-import ToolWrapper from "../../components/ToolWrapper";
-
-// QR Code generation utilities (simplified implementation)
-// For production, you might want to use a library like 'qrcode' or 'qr-code-generator'
-
-// Simple QR Code matrix generation (basic implementation)
-// This is a simplified version - in production you'd use a proper QR library
-function generateQRMatrix(text: string): boolean[][] {
-	// This is a placeholder implementation
-	// In a real implementation, you would use proper QR code algorithms
-	const size = Math.max(21, Math.ceil(Math.sqrt(text.length * 8)) + 4);
-	const matrix: boolean[][] = [];
-
-	// Initialize matrix
-	for (let i = 0; i < size; i++) {
-		matrix[i] = [];
-		for (let j = 0; j < size; j++) {
-			matrix[i][j] = false;
-		}
-	}
-
-	// Simple pattern generation based on text (not a real QR algorithm)
-	let hash = 0;
-	for (let i = 0; i < text.length; i++) {
-		hash = ((hash << 5) - hash + text.charCodeAt(i)) & 0xffffffff;
-	}
-
-	// Create a pseudo-random pattern
-	const random = (seed: number) => {
-		const x = Math.sin(seed) * 10000;
-		return x - Math.floor(x);
-	};
-
-	for (let i = 0; i < size; i++) {
-		for (let j = 0; j < size; j++) {
-			const seed = hash + i * size + j;
-			matrix[i][j] = random(seed) > 0.5;
-		}
-	}
-
-	// Add finder patterns (corners)
-	const addFinderPattern = (x: number, y: number) => {
-		for (let i = 0; i < 7; i++) {
-			for (let j = 0; j < 7; j++) {
-				if (x + i < size && y + j < size) {
-					const isEdge = i === 0 || i === 6 || j === 0 || j === 6;
-					const isInner = i >= 2 && i <= 4 && j >= 2 && j <= 4;
-					matrix[x + i][y + j] = isEdge || isInner;
-				}
-			}
-		}
-	};
-
-	addFinderPattern(0, 0);
-	addFinderPattern(0, size - 7);
-	addFinderPattern(size - 7, 0);
-
-	return matrix;
-}
-
-// Validate URL format
-function isValidURL(string: string): boolean {
-	try {
-		new URL(string);
-		return true;
-	} catch {
-		// Try with http:// prefix
-		try {
-			new URL(`http://${string}`);
-			return true;
-		} catch {
-			return false;
-		}
-	}
-}
-
-// Validate email format
-function isValidEmail(email: string): boolean {
-	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-	return emailRegex.test(email);
-}
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import QRCode from "qrcode";
 
 export default function QRCodeGenerator() {
-	// State management
+	const [inputType, setInputType] = useState<"url" | "text" | "email" | "phone" | "wifi">("url");
 	const [inputText, setInputText] = useState("");
-	const [inputType, setInputType] = useState<
-		"url" | "text" | "email" | "phone" | "wifi"
-	>("url");
-	const [qrSize, setQrSize] = useState(256);
+	const [size, setSize] = useState(256);
 	const [errorLevel, setErrorLevel] = useState<"L" | "M" | "Q" | "H">("M");
+	const [margin, setMargin] = useState(4);
 	const [foregroundColor, setForegroundColor] = useState("#000000");
 	const [backgroundColor, setBackgroundColor] = useState("#ffffff");
-	const [margin, setMargin] = useState(4);
-	const [qrMatrix, setQrMatrix] = useState<boolean[][]>([]);
-	const [isValid, setIsValid] = useState(true);
-	const [validationMessage, setValidationMessage] = useState("");
+	const [processedTexts, setProcessedTexts] = useState<string[]>([]);
+	const [isBulkMode, setIsBulkMode] = useState(false);
+	
+	const canvasRefs = useRef<(HTMLCanvasElement | null)[]>([]);
 
-	const canvasRef = useRef<HTMLCanvasElement>(null);
-
-	// Keyboard shortcuts
-	const keyboardShortcuts = [
-		{ key: "G", description: "QRコード生成" },
-		{ key: "D", description: "PNG ダウンロード" },
-		{ key: "S", description: "SVG ダウンロード" },
-		{ key: "R", description: "リセット" },
-		{ key: "T", description: "テスト" },
-	];
-
-	// Validate input based on type
 	const validateInput = useCallback((text: string, type: string) => {
-		if (!text.trim()) {
-			setIsValid(false);
-			setValidationMessage("入力が必要です");
-			return false;
-		}
-
+		if (!text) return false;
 		switch (type) {
-			case "url":
-				if (!isValidURL(text)) {
-					setIsValid(false);
-					setValidationMessage(
-						"有効なURLを入力してください (例: https://example.com)",
-					);
-					return false;
-				}
-				break;
-			case "email":
-				if (!isValidEmail(text)) {
-					setIsValid(false);
-					setValidationMessage("有効なメールアドレスを入力してください");
-					return false;
-				}
-				break;
-			case "phone": {
-				const phoneRegex = /^[+]?[0-9\-()\s]+$/;
-				if (!phoneRegex.test(text)) {
-					setIsValid(false);
-					setValidationMessage("有効な電話番号を入力してください");
-					return false;
-				}
-				break;
-			}
-			case "wifi":
-				// Basic WiFi QR format validation
-				if (!text.includes("WIFI:")) {
-					setIsValid(false);
-					setValidationMessage(
-						"WiFi形式: WIFI:T:WPA;S:ネットワーク名;P:パスワード;;",
-					);
-					return false;
-				}
-				break;
+			case "url": return text.startsWith("http://") || text.startsWith("https://");
+			case "email": return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(text);
+			case "phone": return /^[\d\+\-\(\)\s]+$/.test(text);
+			case "wifi": return text.includes("WIFI:");
+			default: return true;
 		}
-
-		setIsValid(true);
-		setValidationMessage("");
-		return true;
 	}, []);
 
-	// Generate QR code
-	const generateQR = useCallback(() => {
-		if (!validateInput(inputText, inputType)) {
-			return;
-		}
-
-		let processedText = inputText;
-
-		// Format text based on type
-		switch (inputType) {
-			case "url":
-				if (
-					!inputText.startsWith("http://") &&
-					!inputText.startsWith("https://")
-				) {
-					processedText = `https://${inputText}`;
+	useEffect(() => {
+		const handler = setTimeout(() => {
+			if (inputText) {
+				if (isBulkMode) {
+					const texts = inputText.split("\n").map(t => t.trim()).filter(t => t.length > 0);
+					setProcessedTexts(texts);
+				} else {
+					setProcessedTexts([inputText.trim()]);
 				}
-				break;
-			case "email":
-				processedText = `mailto:${inputText}`;
-				break;
-			case "phone":
-				processedText = `tel:${inputText}`;
-				break;
-			// wifi and text use input as-is
-		}
+			} else {
+				setProcessedTexts([]);
+			}
+		}, 500);
+		return () => clearTimeout(handler);
+	}, [inputText, isBulkMode]);
 
-		const matrix = generateQRMatrix(processedText);
-		setQrMatrix(matrix);
-	}, [inputText, inputType, validateInput]);
+	useEffect(() => {
+		canvasRefs.current = canvasRefs.current.slice(0, processedTexts.length);
+		
+		processedTexts.forEach((text, index) => {
+			const canvas = canvasRefs.current[index];
+			if (canvas) {
+				QRCode.toCanvas(canvas, text, {
+					width: size,
+					margin: margin,
+					errorCorrectionLevel: errorLevel,
+					color: {
+						dark: foregroundColor,
+						light: backgroundColor,
+					},
+				}).catch((err) => {
+					console.error("QR Generation Error:", err);
+				});
+			}
+		});
+	}, [processedTexts, size, margin, errorLevel, foregroundColor, backgroundColor]);
 
-	// Draw QR code on canvas
-	const drawQRCode = useCallback(() => {
-		const canvas = canvasRef.current;
-		if (!canvas || qrMatrix.length === 0) return;
+	const downloadPNG = () => {
+		processedTexts.forEach((text, index) => {
+			const canvas = canvasRefs.current[index];
+			if (!canvas) return;
+			setTimeout(() => {
+				const url = canvas.toDataURL("image/png");
+				const a = document.createElement("a");
+				a.href = url;
+				a.download = processedTexts.length > 1 ? `qrcode_${index + 1}_${Date.now()}.png` : `qrcode_${Date.now()}.png`;
+				document.body.appendChild(a);
+				a.click();
+				document.body.removeChild(a);
+			}, index * 200); // Stagger downloads by 200ms
+		});
+	};
 
-		const ctx = canvas.getContext("2d");
-		if (!ctx) return;
+	const downloadSVG = () => {
+		processedTexts.forEach((text, index) => {
+			setTimeout(() => {
+				QRCode.toString(text, {
+					type: "svg",
+					width: size,
+					margin: margin,
+					errorCorrectionLevel: errorLevel,
+					color: {
+						dark: foregroundColor,
+						light: backgroundColor,
+					},
+				})
+					.then((svg) => {
+						const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
+						const url = URL.createObjectURL(blob);
+						const a = document.createElement("a");
+						a.href = url;
+						a.download = processedTexts.length > 1 ? `qrcode_${index + 1}_${Date.now()}.svg` : `qrcode_${Date.now()}.svg`;
+						document.body.appendChild(a);
+						a.click();
+						document.body.removeChild(a);
+						setTimeout(() => URL.revokeObjectURL(url), 1000);
+					})
+					.catch(console.error);
+			}, index * 200); // Stagger downloads by 200ms
+		});
+	};
 
-		const matrixSize = qrMatrix.length;
-		const cellSize = (qrSize - margin * 2) / matrixSize;
-
-		canvas.width = qrSize;
-		canvas.height = qrSize;
-
-		// Clear canvas with background color
-		ctx.fillStyle = backgroundColor;
-		ctx.fillRect(0, 0, qrSize, qrSize);
-
-		// Draw QR modules
-		ctx.fillStyle = foregroundColor;
-		for (let i = 0; i < matrixSize; i++) {
-			for (let j = 0; j < matrixSize; j++) {
-				if (qrMatrix[i][j]) {
-					ctx.fillRect(
-						margin + j * cellSize,
-						margin + i * cellSize,
-						cellSize,
-						cellSize,
-					);
+	const testQRCode = () => {
+		if (inputType === "url") {
+			processedTexts.forEach((text, index) => {
+				if (validateInput(text, "url")) {
+					setTimeout(() => window.open(text, "_blank"), index * 200);
 				}
-			}
+			});
 		}
-	}, [qrMatrix, qrSize, margin, foregroundColor, backgroundColor]);
+	};
 
-	// Download as PNG
-	const downloadPNG = useCallback(() => {
-		const canvas = canvasRef.current;
-		if (!canvas) return;
-
-		const link = document.createElement("a");
-		link.download = `qrcode-${Date.now()}.png`;
-		link.href = canvas.toDataURL("image/png");
-		link.click();
-	}, []);
-
-	// Download as SVG
-	const downloadSVG = useCallback(() => {
-		if (qrMatrix.length === 0) return;
-
-		const matrixSize = qrMatrix.length;
-		const cellSize = (qrSize - margin * 2) / matrixSize;
-
-		let svgContent = `<svg width="${qrSize}" height="${qrSize}" xmlns="http://www.w3.org/2000/svg">`;
-		svgContent += `<rect width="${qrSize}" height="${qrSize}" fill="${backgroundColor}"/>`;
-
-		for (let i = 0; i < matrixSize; i++) {
-			for (let j = 0; j < matrixSize; j++) {
-				if (qrMatrix[i][j]) {
-					svgContent += `<rect x="${margin + j * cellSize}" y="${margin + i * cellSize}" width="${cellSize}" height="${cellSize}" fill="${foregroundColor}"/>`;
-				}
-			}
-		}
-
-		svgContent += "</svg>";
-
-		const blob = new Blob([svgContent], { type: "image/svg+xml" });
-		const link = document.createElement("a");
-		link.download = `qrcode-${Date.now()}.svg`;
-		link.href = URL.createObjectURL(blob);
-		link.click();
-		URL.revokeObjectURL(link.href);
-	}, [qrMatrix, qrSize, margin, foregroundColor, backgroundColor]);
-
-	// Test QR code by opening URL
-	const testQRCode = useCallback(() => {
-		if (inputType === "url" && isValid && inputText) {
-			let url = inputText;
-			if (!url.startsWith("http://") && !url.startsWith("https://")) {
-				url = `https://${url}`;
-			}
-			window.open(url, "_blank");
-		}
-	}, [inputType, isValid, inputText]);
-
-	// Reset form
-	const resetForm = useCallback(() => {
+	const resetForm = () => {
 		setInputText("");
-		setQrMatrix([]);
-		setIsValid(true);
-		setValidationMessage("");
-	}, []);
+		setSize(256);
+		setErrorLevel("M");
+		setMargin(4);
+		setForegroundColor("#000000");
+		setBackgroundColor("#ffffff");
+	};
 
-	// Handle keyboard shortcuts
-	useEffect(() => {
-		const handleToolShortcut = (event: CustomEvent) => {
-			switch (event.detail.key.toLowerCase()) {
-				case "g":
-					generateQR();
-					break;
-				case "d":
-					downloadPNG();
-					break;
-				case "s":
-					downloadSVG();
-					break;
-				case "r":
-					resetForm();
-					break;
-				case "t":
-					testQRCode();
-					break;
-			}
-		};
-
-		document.addEventListener(
-			"toolShortcut",
-			handleToolShortcut as EventListener,
-		);
-		return () =>
-			document.removeEventListener(
-				"toolShortcut",
-				handleToolShortcut as EventListener,
-			);
-	}, [generateQR, downloadPNG, downloadSVG, resetForm, testQRCode]);
-
-	// Auto-generate QR when input changes
-	useEffect(() => {
-		if (inputText.trim()) {
-			const timer = setTimeout(() => {
-				generateQR();
-			}, 500); // Debounce
-			return () => clearTimeout(timer);
-		} else {
-			setQrMatrix([]);
-		}
-	}, [inputText, generateQR]);
-
-	// Draw QR code when matrix changes
-	useEffect(() => {
-		drawQRCode();
-	}, [drawQRCode]);
-
-	// Design system classes
-	const CardStyle =
-		"rounded-xl bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)] p-4 space-y-4";
-	const Section_title = "neue-haas-grotesk-display text-xl text-main mb-4";
-	const Input_style =
-		"rounded-lg bg-main/10 p-2 text-main focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base w-full";
-
-	const Select_style =
-		"rounded-lg bg-main/10 p-2 text-main focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base";
+	const hasValidInput = processedTexts.length > 0;
 
 	return (
-		<ToolWrapper
-			toolName="QR Code Generator"
-			description="URL・テキストからQRコード生成・カスタマイズ・ダウンロード機能.PNG・SVG形式でエクスポート可能.オフライン対応."
-			category="utility"
-			keyboardShortcuts={keyboardShortcuts}
-		>
-			<div className="space-y-8">
-				{/* Input Section */}
-				<section className={CardStyle}>
-					<h3 className={Section_title}>Input & Type</h3>
+		<div style={{ position: "fixed", top: 0, left: 0, width: "100vw", height: "100vh", zIndex: 9999, backgroundColor: "#ffffff", color: "#000000", fontFamily: "sans-serif", overflowY: "auto", padding: "2rem" }}>
+			<div style={{ maxWidth: "900px", margin: "0 auto" }}>
+				
+				<nav style={{ fontSize: "0.85rem", marginBottom: "1rem", color: "#666" }}>
+					<a href="/" style={{ color: "#0066cc", textDecoration: "none" }}>Home</a>
+					<span style={{ margin: "0 8px" }}>/</span>
+					<a href="/tools" style={{ color: "#0066cc", textDecoration: "none" }}>Tools</a>
+					<span style={{ margin: "0 8px" }}>/</span>
+					<span style={{ color: "#000" }}>QR Code Generator</span>
+				</nav>
 
-					<div className="space-y-4">
-						{/* Input Type Selection */}
-						<div>
-							<label className="neue-haas-grotesk-display text-sm text-main mb-2 block">
-								Input Type
-							</label>
-							<AccessibleSelect
-								value={inputType}
-								onChange={(e) =>
-									setInputType(
-										e.target.value as
-											| "url"
-											| "text"
-											| "email"
-											| "phone"
-											| "wifi",
-									)
-								}
-								label="Input Type"
-								options={[
-									{ value: "url", label: "URL" },
-									{ value: "text", label: "Plain Text" },
-									{ value: "email", label: "Email" },
-									{ value: "phone", label: "Phone Number" },
-									{ value: "wifi", label: "WiFi Network" },
-								]}
-								aria-label="Select input type"
-							/>
-						</div>
+				<h1 style={{ borderBottom: "1px solid #ccc", paddingBottom: "10px", marginBottom: "20px", fontSize: "1.5rem", fontWeight: "normal" }}>
+					QR Code Generator
+				</h1>
 
-						{/* Text Input */}
-						<div>
-							<label className="neue-haas-grotesk-display text-sm text-main mb-2 block">
-								{inputType === "url" && "URL (例: https://example.com)"}
-								{inputType === "text" && "Text Content"}
-								{inputType === "email" && "Email Address"}
-								{inputType === "phone" && "Phone Number"}
-								{inputType === "wifi" &&
-									"WiFi Format: WIFI:T:WPA;S:NetworkName;P:Password;;"}
-							</label>
-							<textarea
-								value={inputText}
-								onChange={(e) => setInputText(e.target.value)}
-								placeholder={
-									inputType === "url"
-										? "https://example.com"
-										: inputType === "text"
-											? "Enter any text..."
-											: inputType === "email"
-												? "user@example.com"
-												: inputType === "phone"
-													? "+81-90-1234-5678"
-													: "WIFI:T:WPA;S:MyNetwork;P:MyPassword;;"
-								}
-								className={`${Input_style} min-h-[80px] resize-y`}
-								aria-label={`Enter ${inputType} content`}
-								aria-invalid={!isValid}
-								aria-describedby={!isValid ? "validation-message" : undefined}
-							/>
-							{!isValid && (
-								<p
-									id="validation-message"
-									className="text-accent text-sm mt-2"
-									role="alert"
-								>
-									{validationMessage}
-								</p>
-							)}
-						</div>
-					</div>
-				</section>
+				<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "40px" }}>
+					
+					{/* Left Column: Controls */}
+					<div>
+						<fieldset style={{ border: "1px solid #ccc", padding: "15px", marginBottom: "20px" }}>
+							<legend>Input Settings</legend>
+							<div style={{ display: "grid", gridTemplateColumns: "100px 1fr", gap: "10px" }}>
+								<label htmlFor="inputType" style={{ alignSelf: "center" }}>Type:</label>
+								<select id="inputType" value={inputType} onChange={(e) => setInputType(e.target.value as any)} style={{ all: "revert" }}>
+									<option value="url">URL</option>
+									<option value="text">Text</option>
+									<option value="email">Email</option>
+									<option value="phone">Phone</option>
+									<option value="wifi">WiFi</option>
+								</select>
 
-				{/* Customization Section */}
-				<section className={CardStyle}>
-					<h3 className={Section_title}>Customization</h3>
+								<label style={{ alignSelf: "center" }}>Mode:</label>
+								<div style={{ display: "flex", alignItems: "center", gap: "15px" }}>
+									<label style={{ display: "flex", alignItems: "center", gap: "5px", cursor: "pointer" }}>
+										<input type="radio" checked={!isBulkMode} onChange={() => setIsBulkMode(false)} style={{ all: "revert" }} />
+										Single
+									</label>
+									<label style={{ display: "flex", alignItems: "center", gap: "5px", cursor: "pointer" }}>
+										<input type="radio" checked={isBulkMode} onChange={() => setIsBulkMode(true)} style={{ all: "revert" }} />
+										Bulk
+									</label>
+								</div>
 
-					<div className="grid-system grid-1 sm:grid-2 gap-6">
-						{/* Size Settings */}
-						<div className="space-y-4">
-							<div>
-								<label className="neue-haas-grotesk-display text-sm text-main mb-2 block">
-									Size: {qrSize}px
+								<label htmlFor="inputText" style={{ alignSelf: isBulkMode ? "start" : "center", marginTop: isBulkMode ? "4px" : "0" }}>
+									Content:
 								</label>
-								<input
-									type="range"
-									min="128"
-									max="512"
-									step="32"
-									value={qrSize}
-									onChange={(e) => setQrSize(parseInt(e.target.value, 10))}
-									className="w-full"
-									aria-label="QR code size"
-								/>
+								{isBulkMode ? (
+									<textarea 
+										id="inputText"
+										value={inputText} 
+										onChange={(e) => setInputText(e.target.value)} 
+										placeholder="Enter content here (1 line = 1 QR)..."
+										rows={4}
+										style={{ all: "revert", padding: "4px", width: "100%", boxSizing: "border-box", resize: "vertical" }}
+									/>
+								) : (
+									<input 
+										id="inputText"
+										type="text"
+										value={inputText} 
+										onChange={(e) => setInputText(e.target.value)} 
+										placeholder="Enter content here..."
+										style={{ all: "revert", padding: "2px 4px", width: "100%", boxSizing: "border-box" }}
+									/>
+								)}
 							</div>
+						</fieldset>
 
-							<div>
-								<label className="neue-haas-grotesk-display text-sm text-main mb-2 block">
-									Margin: {margin}px
-								</label>
-								<input
-									type="range"
-									min="0"
-									max="20"
-									value={margin}
-									onChange={(e) => setMargin(parseInt(e.target.value, 10))}
-									className="w-full"
-									aria-label="QR code margin"
-								/>
-							</div>
+						<fieldset style={{ border: "1px solid #ccc", padding: "15px", marginBottom: "20px" }}>
+							<legend>QR Parameters</legend>
+							<div style={{ display: "grid", gridTemplateColumns: "100px 1fr", gap: "10px", alignItems: "center" }}>
+								<label htmlFor="sizeRange">Size:</label>
+								<div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+									<input 
+										id="sizeRange"
+										type="range" 
+										min="128" max="1024" step="32" 
+										value={size} 
+										onChange={(e) => setSize(Number(e.target.value))} 
+										style={{ all: "revert", flex: 1 }}
+									/>
+									<span style={{ width: "50px", textAlign: "right" }}>{size}px</span>
+								</div>
 
-							<div>
-								<label className="neue-haas-grotesk-display text-sm text-main mb-2 block">
-									Error Correction Level
-								</label>
-								<select
-									value={errorLevel}
-									onChange={(e) =>
-										setErrorLevel(e.target.value as "L" | "M" | "Q" | "H")
-									}
-									className={Select_style}
-									aria-label="Error correction level"
-								>
+								<label htmlFor="marginRange">Margin:</label>
+								<div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+									<input 
+										id="marginRange"
+										type="range" 
+										min="0" max="10" step="1" 
+										value={margin} 
+										onChange={(e) => setMargin(Number(e.target.value))} 
+										style={{ all: "revert", flex: 1 }}
+									/>
+									<span style={{ width: "50px", textAlign: "right" }}>{margin}</span>
+								</div>
+
+								<label htmlFor="errorLevel">Error Corr:</label>
+								<select id="errorLevel" value={errorLevel} onChange={(e) => setErrorLevel(e.target.value as any)} style={{ all: "revert" }}>
 									<option value="L">Low (7%)</option>
 									<option value="M">Medium (15%)</option>
 									<option value="Q">Quartile (25%)</option>
 									<option value="H">High (30%)</option>
 								</select>
 							</div>
-						</div>
+						</fieldset>
 
-						{/* Color Settings */}
-						<div className="space-y-4">
-							<div>
-								<label className="neue-haas-grotesk-display text-sm text-main mb-2 block">
-									Foreground Color
-								</label>
-								<div className="flex items-center space-x-2">
-									<input
-										type="color"
-										value={foregroundColor}
-										onChange={(e) => setForegroundColor(e.target.value)}
-										className="w-12 h-8 rounded bg-main/10 cursor-pointer hover:bg-main/20 transition-colors"
-										aria-label="Foreground color picker"
+						<fieldset style={{ border: "1px solid #ccc", padding: "15px" }}>
+							<legend>Colors</legend>
+							<div style={{ display: "grid", gridTemplateColumns: "100px 1fr", gap: "10px", alignItems: "center" }}>
+								<label htmlFor="fgColor">Foreground:</label>
+								<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+									<input 
+										id="fgColor"
+										type="color" 
+										value={foregroundColor} 
+										onChange={(e) => setForegroundColor(e.target.value)} 
+										style={{ all: "revert" }}
 									/>
-									<input
-										type="text"
-										value={foregroundColor}
+									<input 
+										type="text" 
+										value={foregroundColor} 
 										onChange={(e) => setForegroundColor(e.target.value)}
-										className="flex-1 rounded-lg bg-main/10 p-2 text-main focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
-										placeholder="#000000"
-										aria-label="Foreground color hex value"
+										style={{ all: "revert", flex: 1, padding: "2px 4px" }}
+									/>
+								</div>
+
+								<label htmlFor="bgColor">Background:</label>
+								<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+									<input 
+										id="bgColor"
+										type="color" 
+										value={backgroundColor} 
+										onChange={(e) => setBackgroundColor(e.target.value)} 
+										style={{ all: "revert" }}
+									/>
+									<input 
+										type="text" 
+										value={backgroundColor} 
+										onChange={(e) => setBackgroundColor(e.target.value)}
+										style={{ all: "revert", flex: 1, padding: "2px 4px" }}
 									/>
 								</div>
 							</div>
-
-							<div>
-								<label className="neue-haas-grotesk-display text-sm text-main mb-2 block">
-									Background Color
-								</label>
-								<div className="flex items-center space-x-2">
-									<input
-										type="color"
-										value={backgroundColor}
-										onChange={(e) => setBackgroundColor(e.target.value)}
-										className="w-12 h-8 rounded bg-main/10 cursor-pointer hover:bg-main/20 transition-colors"
-										aria-label="Background color picker"
-									/>
-									<input
-										type="text"
-										value={backgroundColor}
-										onChange={(e) => setBackgroundColor(e.target.value)}
-										className="flex-1 rounded-lg bg-main/10 p-2 text-main focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
-										placeholder="#ffffff"
-										aria-label="Background color hex value"
-									/>
-								</div>
-							</div>
-						</div>
+						</fieldset>
 					</div>
-				</section>
 
-				{/* QR Code Display */}
-				{qrMatrix.length > 0 && (
-					<section className={CardStyle}>
-						<h3 className={Section_title}>Generated QR Code</h3>
-
-						<div className="text-center space-y-4">
-							<canvas
-								ref={canvasRef}
-								className="rounded-lg bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)] mx-auto"
-								style={{ maxWidth: "100%", height: "auto" }}
-								aria-label="Generated QR code"
-							/>
-
-							<div className="flex flex-wrap justify-center gap-4">
-								<AccessibleButton
-									onClick={generateQR}
-									variant="primary"
-									shortcut="G"
-									announceOnClick="QRコードを生成しました"
-									aria-label="Regenerate QR code"
-								>
-									Generate
-								</AccessibleButton>
-								<AccessibleButton
-									onClick={downloadPNG}
-									variant="secondary"
-									shortcut="D"
-									announceOnClick="PNGファイルをダウンロードしました"
-									aria-label="Download as PNG"
-								>
-									PNG Download
-								</AccessibleButton>
-								<AccessibleButton
-									onClick={downloadSVG}
-									variant="secondary"
-									shortcut="S"
-									announceOnClick="SVGファイルをダウンロードしました"
-									aria-label="Download as SVG"
-								>
-									SVG Download
-								</AccessibleButton>
-								{inputType === "url" && (
-									<button
-										type="button"
-										onClick={testQRCode}
-										className="rounded-lg bg-main/10 px-4 py-2 hover:bg-main/20 transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
-										aria-label="Test URL in new tab"
-									>
-										Test URL (T)
-									</button>
+					{/* Right Column: Output */}
+					<div style={{ display: "flex", flexDirection: "column" }}>
+						<div style={{ border: "1px solid #ccc", padding: "15px", marginBottom: "20px", flex: 1, display: "flex", flexDirection: "column" }}>
+							<div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "15px" }}>
+								<h2 style={{ fontSize: "1.1rem", margin: 0, fontWeight: "normal" }}>Generated QR {isBulkMode ? "Codes" : "Code"}</h2>
+								{isBulkMode && <span style={{ fontSize: "0.85rem", color: "#666" }}>Total: {processedTexts.length}</span>}
+							</div>
+							
+							<div style={{ 
+								width: "100%", 
+								backgroundColor: "#f9f9f9", 
+								border: "1px solid #eee",
+								display: "flex", 
+								flexWrap: "wrap",
+								gap: "20px",
+								alignItems: "center", 
+								justifyContent: "center",
+								padding: "20px",
+								boxSizing: "border-box",
+								minHeight: "300px",
+								overflowY: "auto",
+								flex: 1
+							}}>
+								{processedTexts.length > 0 ? (
+									processedTexts.map((text, index) => (
+										<div key={index} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "10px", background: "#fff", padding: "10px", border: "1px solid #ddd", boxShadow: "0 2px 4px rgba(0,0,0,0.05)" }}>
+											<canvas 
+												ref={(el) => {
+													canvasRefs.current[index] = el;
+												}} 
+												style={{ width: "100%", maxWidth: `${size}px`, height: "auto", display: "block" }} 
+											/>
+											<div style={{ fontSize: "0.75rem", color: "#666", maxWidth: "150px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={text}>
+												#{index + 1}: {text}
+											</div>
+										</div>
+									))
+								) : (
+									<span style={{ color: "#999" }}>[ No Data ]</span>
 								)}
-								<button
-									type="button"
-									onClick={resetForm}
-									className="rounded-lg bg-main/10 px-4 py-2 hover:bg-main/20 transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
-									aria-label="Reset form"
-								>
-									Reset (R)
-								</button>
-							</div>
-						</div>
-					</section>
-				)}
-
-				{/* Information Section */}
-				<section className={CardStyle}>
-					<h3 className={Section_title}>Information</h3>
-
-					<div className="space-y-4">
-						<div className="grid-system grid-1 sm:grid-2 gap-6">
-							<div>
-								<h4 className="neue-haas-grotesk-display text-lg text-main mb-2">
-									Features
-								</h4>
-								<ul className="noto-sans-jp-light text-sm space-y-1">
-									<li>• URL・テキスト・メール・電話・WiFi対応</li>
-									<li>• カスタマイズ可能な色・サイズ・マージン</li>
-									<li>• PNG・SVG形式でダウンロード</li>
-									<li>• エラー訂正レベル調整</li>
-									<li>• リアルタイムプレビュー</li>
-									<li>• オフライン動作・ローカル処理</li>
-								</ul>
 							</div>
 
-							<div>
-								<h4 className="neue-haas-grotesk-display text-lg text-main mb-2">
-									Usage Tips
-								</h4>
-								<ul className="noto-sans-jp-light text-sm space-y-1">
-									<li>• URLは自動的にhttps://が追加されます</li>
-									<li>• エラー訂正レベルが高いほど読み取り精度向上</li>
-									<li>• 高コントラストの色を推奨</li>
-									<li>• 印刷時は300DPI以上を推奨</li>
-									<li>• WiFi形式: WIFI:T:WPA;S:名前;P:パスワード;;</li>
-								</ul>
+							<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "10px", marginTop: "15px" }}>
+								<button onClick={downloadPNG} disabled={!hasValidInput} style={{ all: "revert", fontSize: "13px", padding: "4px 8px" }}>Download PNG</button>
+								<button onClick={downloadSVG} disabled={!hasValidInput} style={{ all: "revert", fontSize: "13px", padding: "4px 8px" }}>Download SVG</button>
+								{inputType === "url" && (
+									<button onClick={testQRCode} disabled={!hasValidInput} style={{ all: "revert", fontSize: "13px", padding: "4px 8px" }}>Test URLs</button>
+								)}
+								<button onClick={resetForm} style={{ all: "revert", fontSize: "13px", padding: "4px 8px" }}>Reset</button>
 							</div>
-						</div>
-
-						<div className="rounded-xl bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)] p-4">
-							<p className="noto-sans-jp-light text-xs text-center">
-								注意: このツールは簡易的なQRコード生成機能です.
-								商用利用や重要な用途には専用ライブラリの使用を推奨します.
-								すべての処理はローカルで実行され、データは外部に送信されません.
-							</p>
 						</div>
 					</div>
-				</section>
+
+				</div>
 			</div>
-		</ToolWrapper>
+		</div>
 	);
 }

--- a/src/app/tools/qr-generator/page.tsx
+++ b/src/app/tools/qr-generator/page.tsx
@@ -29,26 +29,7 @@ export const metadata = {
 export default function QRGeneratorPage() {
 	return (
 		<>
-			<div className="relative min-h-screen bg-base text-main">
-				<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
-					<div className="container-system">
-						<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">
-							<Breadcrumbs
-								items={[
-									{ label: "Home", href: "/" },
-									{ label: "Tools", href: "/tools" },
-									{ label: "QR Code Generator", isCurrent: true },
-								]}
-								className="pt-4"
-							/>
-
-							<section className="space-y-6">
-								<QRCodeGenerator />
-							</section>
-						</div>
-					</div>
-				</main>
-			</div>
+			<QRCodeGenerator />
 
 			{/* Structured Data */}
 			<script type="application/ld+json">

--- a/src/app/tools/sequential-png-preview/page.tsx
+++ b/src/app/tools/sequential-png-preview/page.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
 
 export default function SequentialPngPreviewPage() {
 	return (
-		<div className="relative min-h-screen bg-base text-main">
+		<div className="relative min-h-screen text-main">
 			<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
 				<div className="container-system">
 					<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/tools/svg2tsx/page.tsx
+++ b/src/app/tools/svg2tsx/page.tsx
@@ -59,7 +59,7 @@ export default function SVGToTSXPage() {
 	return (
 		<>
 			<script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-			<div className="relative min-h-screen bg-base text-main">
+			<div className="relative min-h-screen text-main">
 				<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
 					<div className="container-system">
 						<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/tools/text-counter/components/SettingsPanel.tsx
+++ b/src/app/tools/text-counter/components/SettingsPanel.tsx
@@ -61,6 +61,53 @@ export default function SettingsPanel({
 							handleCountSettingChange("includeWhitespace", checked)
 						}
 					/>
+					<CheckboxSetting
+						id="exclude-html"
+						label="HTMLタグを除外"
+						checked={settings.excludeHtml}
+						onChange={(checked) =>
+							handleCountSettingChange("excludeHtml", checked)
+						}
+					/>
+					<CheckboxSetting
+						id="exclude-urls"
+						label="URLを除外"
+						checked={settings.excludeUrls}
+						onChange={(checked) =>
+							handleCountSettingChange("excludeUrls", checked)
+						}
+					/>
+				</div>
+
+				<div className="space-y-2 mt-4">
+					<h4 className="text-sm font-medium text-main">チェック設定</h4>
+					
+					<div className="space-y-3">
+						<CheckboxSetting
+							id="check-half-kana"
+							label="半角カナを検出する"
+							checked={settings.checkHalfKana}
+							onChange={(checked) =>
+								handleCountSettingChange("checkHalfKana", checked)
+							}
+						/>
+
+						<div>
+							<label htmlFor="specific-string" className="block text-sm text-main mb-1">
+								特定文字列の出現数チェック
+							</label>
+							<input
+								type="text"
+								id="specific-string"
+								value={settings.specificString || ""}
+								onChange={(e) =>
+									handleCountSettingChange("specificString", e.target.value)
+								}
+								placeholder="検索したい文字列"
+								className="w-full p-2 rounded-lg bg-main/10 text-main focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base"
+							/>
+						</div>
+					</div>
 				</div>
 
 				<div className="space-y-2">

--- a/src/app/tools/text-counter/components/StatisticsDisplay.tsx
+++ b/src/app/tools/text-counter/components/StatisticsDisplay.tsx
@@ -1,20 +1,132 @@
 "use client";
 
-import type { DisplaySettings, TextStats } from "../types";
+import type { CountSettings, DisplaySettings, TextStats } from "../types";
 import CharacterTypeChart from "./CharacterTypeChart";
 
 interface StatisticsDisplayProps {
 	stats: TextStats;
 	displaySettings: DisplaySettings;
+	settings: CountSettings;
+	onSettingsChange?: (settings: CountSettings) => void;
 }
 
 export default function StatisticsDisplay({
 	stats,
 	displaySettings,
+	settings,
+	onSettingsChange,
 }: StatisticsDisplayProps) {
+	const updateSetting = (key: keyof CountSettings, value: number) => {
+		if (onSettingsChange) {
+			onSettingsChange({ ...settings, [key]: value });
+		}
+	};
+
+	const hasLimits = settings.targetLength > 0 || settings.maxLength > 0;
+	// Define the max value for the bar's scale
+	const scaleMax = Math.max(
+		settings.maxLength || 0,
+		settings.targetLength || 0,
+		settings.minLength || 0,
+		stats.totalCharacters,
+		1 // Avoid division by zero
+	);
+
+	const progressPercent = Math.min(100, (stats.totalCharacters / scaleMax) * 100);
+	
+	const getStatusColor = () => {
+		if (settings.maxLength > 0 && stats.totalCharacters > settings.maxLength) return "bg-red-500";
+		if (settings.targetLength > 0 && stats.totalCharacters >= settings.targetLength) return "bg-accent";
+		if (settings.minLength > 0 && stats.totalCharacters >= settings.minLength) return "bg-green-500";
+		return "bg-blue-400";
+	};
+
 	return (
 		<div className="space-y-6">
 			<h2 className="text-xl font-semibold text-main">統計情報</h2>
+
+			<div className="rounded-xl bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)] p-6 space-y-6">
+				<div className="flex flex-wrap items-center gap-4 text-sm">
+					<div className="flex items-center gap-2">
+						<label htmlFor="min-length" className="text-main/80">下限:</label>
+						<input 
+							id="min-length"
+							type="number" 
+							min="0"
+							className="w-20 bg-main/10 rounded px-2 py-1 text-center font-mono focus:outline-none focus:ring-1 focus:ring-accent"
+							value={settings.minLength || 0}
+							onChange={(e) => updateSetting("minLength", parseInt(e.target.value) || 0)}
+							disabled={!onSettingsChange}
+						/>
+					</div>
+					<div className="flex items-center gap-2">
+						<label htmlFor="target-length" className="text-main/80">目標:</label>
+						<input 
+							id="target-length"
+							type="number" 
+							min="0"
+							className="w-20 bg-main/10 rounded px-2 py-1 text-center font-mono focus:outline-none focus:ring-1 focus:ring-accent"
+							value={settings.targetLength || 0}
+							onChange={(e) => updateSetting("targetLength", parseInt(e.target.value) || 0)}
+							disabled={!onSettingsChange}
+						/>
+					</div>
+					<div className="flex items-center gap-2">
+						<label htmlFor="max-length" className="text-main/80">上限:</label>
+						<input 
+							id="max-length"
+							type="number" 
+							min="0"
+							className="w-20 bg-main/10 rounded px-2 py-1 text-center font-mono focus:outline-none focus:ring-1 focus:ring-accent"
+							value={settings.maxLength || 0}
+							onChange={(e) => updateSetting("maxLength", parseInt(e.target.value) || 0)}
+							disabled={!onSettingsChange}
+						/>
+					</div>
+				</div>
+
+				<div className="space-y-2">
+					<div className="flex justify-between text-sm font-medium text-main">
+						<span>0</span>
+						<span>{scaleMax.toLocaleString()} 文字</span>
+					</div>
+					<div className="relative w-full h-4 bg-main/10 rounded-full overflow-hidden">
+						{/* Progress Bar */}
+						<div 
+							className={`h-full transition-all duration-300 ease-out ${getStatusColor()}`} 
+							style={{ width: `${progressPercent}%` }}
+						></div>
+						
+						{/* Min Marker */}
+						{settings.minLength > 0 && settings.minLength <= scaleMax && (
+							<div 
+								className="absolute top-0 bottom-0 w-0.5 bg-main/30 z-10"
+								style={{ left: `${(settings.minLength / scaleMax) * 100}%` }}
+								title={`下限: ${settings.minLength}`}
+							></div>
+						)}
+						{/* Target Marker */}
+						{settings.targetLength > 0 && settings.targetLength <= scaleMax && (
+							<div 
+								className="absolute top-0 bottom-0 w-1 bg-main/50 z-10"
+								style={{ left: `${(settings.targetLength / scaleMax) * 100}%` }}
+								title={`目標: ${settings.targetLength}`}
+							></div>
+						)}
+						{/* Max Marker */}
+						{settings.maxLength > 0 && settings.maxLength <= scaleMax && (
+							<div 
+								className="absolute top-0 bottom-0 w-0.5 bg-red-500/50 z-10"
+								style={{ left: `${(settings.maxLength / scaleMax) * 100}%` }}
+								title={`上限: ${settings.maxLength}`}
+							></div>
+						)}
+					</div>
+					<div className="text-right text-sm font-bold text-main">
+						現在: {stats.totalCharacters.toLocaleString()} 文字
+					</div>
+				</div>
+			</div>
 
 			{displaySettings.showBasicStats && (
 				<div className="rounded-xl bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)] p-4 space-y-3">
@@ -32,6 +144,14 @@ export default function StatisticsDisplay({
 						<StatItem
 							label="空白除く"
 							value={stats.charactersWithoutWhitespace}
+						/>
+						<StatItem 
+							label="400字詰め原稿用紙" 
+							value={`${stats.manuscriptPages400} 枚`} 
+						/>
+						<StatItem 
+							label="バイト数 (UTF-8)" 
+							value={`${stats.byteSizeUTF8.toLocaleString()} B`} 
 						/>
 					</div>
 				</div>
@@ -61,6 +181,9 @@ export default function StatisticsDisplay({
 							value={stats.characterTypes.alphanumeric}
 						/>
 						<StatItem label="記号" value={stats.characterTypes.symbols} />
+						{settings.checkHalfKana && (
+							<StatItem label="半角カナ" value={stats.halfKanaCount} />
+						)}
 					</div>
 
 					{displaySettings.showGraphs && (
@@ -88,6 +211,12 @@ export default function StatisticsDisplay({
 							label="平均行単語数"
 							value={stats.averageWordsPerLine.toFixed(1)}
 						/>
+						{settings.specificString && (
+							<StatItem
+								label={`「${settings.specificString}」出現数`}
+								value={stats.specificStringCount}
+							/>
+						)}
 					</div>
 				</div>
 			)}

--- a/src/app/tools/text-counter/components/TextCounterTool.tsx
+++ b/src/app/tools/text-counter/components/TextCounterTool.tsx
@@ -1,43 +1,53 @@
 "use client";
 
-import { BarChart3, Copy, RotateCcw, Settings } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
-import type { CountSettings, DisplaySettings, TextStats } from "../types";
+import type { CountSettings, TextStats } from "../types";
 import { calculateTextStats } from "../utils/textAnalysis";
-import SettingsPanel from "./SettingsPanel";
-import StatisticsDisplay from "./StatisticsDisplay";
-import TextInput from "./TextInput";
+import { RawDOMContainer } from "../../components/RawDOMContainer";
+
+import { getEncoding } from "js-tiktoken";
 
 const DEFAULT_SETTINGS: CountSettings = {
 	includeSpaces: true,
 	includeNewlines: true,
 	includeWhitespace: true,
 	countMethod: "all",
-};
-
-const DEFAULT_DISPLAY: DisplaySettings = {
-	showBasicStats: true,
-	showDetailedStats: true,
-	showCharacterTypes: true,
-	showStructureStats: true,
-	showGraphs: false,
-	theme: "light",
-	fontSize: "medium",
+	targetLength: 400,
+	minLength: 1000,
+	maxLength: 1000,
+	checkHalfKana: false,
+	specificString: "",
+	excludeHtml: false,
+	excludeUrls: false,
 };
 
 export default function TextCounterTool() {
 	const [text, setText] = useState("");
 	const [settings, setSettings] = useState<CountSettings>(DEFAULT_SETTINGS);
-	const [displaySettings, setDisplaySettings] =
-		useState<DisplaySettings>(DEFAULT_DISPLAY);
-	const [showSettings, setShowSettings] = useState(false);
+	const [isTokenizerOpen, setIsTokenizerOpen] = useState(false);
 
 	const stats: TextStats = useMemo(() => {
 		return calculateTextStats(text, settings);
 	}, [text, settings]);
 
-	const handleTextChange = useCallback((newText: string) => {
-		setText(newText);
+	const tokenData = useMemo(() => {
+		if (!isTokenizerOpen || !text) return { count: null, blocks: [] as { id: number; str: string }[] };
+		try {
+			const enc = getEncoding("o200k_base");
+			const tokens = enc.encode(text);
+			const blocks = [];
+			for (let i = 0; i < tokens.length; i++) {
+				blocks.push({ id: tokens[i], str: enc.decode([tokens[i]]) });
+			}
+			return { count: tokens.length, blocks };
+		} catch (e) {
+			console.error("Tokenizer error:", e);
+			return { count: null, blocks: [] };
+		}
+	}, [text, isTokenizerOpen]);
+
+	const handleTextChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+		setText(e.target.value);
 	}, []);
 
 	const handleClear = useCallback(() => {
@@ -45,100 +55,212 @@ export default function TextCounterTool() {
 	}, []);
 
 	const handleCopyText = useCallback(() => {
-		navigator.clipboard.writeText(text).then(() => {
-			// Could add a toast notification here
-		});
+		navigator.clipboard.writeText(text);
 	}, [text]);
 
+    const handleSettingChange = (key: keyof CountSettings, value: any) => {
+        setSettings(prev => ({ ...prev, [key]: value }));
+    };
+
 	return (
-		<div
-			className="space-y-6"
-			role="application"
-			aria-label="Text Counter Tool"
+		<RawDOMContainer
+			title="Text Counter"
+			breadcrumbs={[
+				{ label: "Home", href: "/" },
+				{ label: "Tools", href: "/tools" },
+				{ label: "Text Counter" }
+			]}
 		>
-			<div className="flex justify-between items-center">
-				<div className="flex gap-2">
-					<button
-						type="button"
-						onClick={handleClear}
-						className="flex items-center justify-center w-10 h-10 rounded-lg bg-main/10 hover:bg-main/20 transition-colors"
-						aria-label="テキストをクリア"
-						title="クリア"
-					>
-						<RotateCcw size={16} />
-					</button>
-					<button
-						type="button"
-						onClick={handleCopyText}
-						className="flex items-center justify-center w-10 h-10 rounded-lg bg-main/10 hover:bg-main/20 transition-colors"
-						aria-label="テキストをコピー"
-						title="テキストをコピー"
-					>
-						<Copy size={16} />
-					</button>
-				</div>
-
-				<div className="flex gap-2">
-					<button
-						type="button"
-						onClick={() =>
-							setDisplaySettings((prev) => ({
-								...prev,
-								showGraphs: !prev.showGraphs,
-							}))
-						}
-						className={`flex items-center justify-center w-10 h-10 rounded-lg transition-colors ${
-							displaySettings.showGraphs
-								? "bg-main/30 text-main"
-								: "bg-main/10 hover:bg-main/20"
-						}`}
-						aria-label="グラフ表示を切り替え"
-						title="グラフ"
-					>
-						<BarChart3 size={16} />
-					</button>
-					<button
-						type="button"
-						onClick={() => setShowSettings(!showSettings)}
-						className={`flex items-center justify-center w-10 h-10 rounded-lg transition-colors ${
-							showSettings
-								? "bg-main/30 text-main"
-								: "bg-main/10 hover:bg-main/20"
-						}`}
-						aria-label="設定パネルを切り替え"
-						title="設定"
-					>
-						<Settings size={16} />
-					</button>
-				</div>
-			</div>
-
-			<div className="space-y-6">
-				<TextInput
-					value={text}
-					onChange={handleTextChange}
-					placeholder="ここにテキストを入力してください..."
-					fontSize={displaySettings.fontSize}
-				/>
-
-				<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-					{showSettings && (
-						<SettingsPanel
-							settings={settings}
-							displaySettings={displaySettings}
-							onSettingsChange={setSettings}
-							onDisplaySettingsChange={setDisplaySettings}
-						/>
-					)}
-
-					<div className={showSettings ? "" : "lg:col-span-2"}>
-						<StatisticsDisplay
-							stats={stats}
-							displaySettings={displaySettings}
-						/>
+			{/* Override responsive styles minimally via inline media queries isn't easy, so we rely on flex-wrap or auto-fit. */}
+			<div style={{ display: "flex", flexWrap: "wrap", gap: "20px" }}>
+				
+				{/* Left: Input & Basic Actions */}
+				<div style={{ flex: "1 1 500px", display: "flex", flexDirection: "column", gap: "15px" }}>
+					<textarea 
+						value={text} 
+						onChange={handleTextChange}
+						placeholder="Enter text here..."
+						style={{ all: "revert", width: "100%", height: "400px", padding: "10px", boxSizing: "border-box", fontFamily: "monospace" }}
+					/>
+					<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "10px" }}>
+						<button onClick={handleClear} style={{ all: "revert", padding: "4px 12px", fontSize: "13px", width: "100%", boxSizing: "border-box" }}>Clear</button>
+						<button onClick={handleCopyText} style={{ all: "revert", padding: "4px 12px", fontSize: "13px", width: "100%", boxSizing: "border-box" }}>Copy Text</button>
 					</div>
+
+					{/* Settings Fieldset */}
+					<fieldset style={{ border: "1px solid #ccc", padding: "15px" }}>
+						<legend>Settings</legend>
+						<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "10px", fontSize: "0.9rem" }}>
+							<label style={{ display: "flex", alignItems: "center", gap: "5px", cursor: "pointer" }}>
+								<input type="checkbox" checked={settings.includeSpaces} onChange={(e) => handleSettingChange("includeSpaces", e.target.checked)} style={{ all: "revert" }} />
+								Include Spaces
+							</label>
+							<label style={{ display: "flex", alignItems: "center", gap: "5px", cursor: "pointer" }}>
+								<input type="checkbox" checked={settings.includeNewlines} onChange={(e) => handleSettingChange("includeNewlines", e.target.checked)} style={{ all: "revert" }} />
+								Include Newlines
+							</label>
+							<label style={{ display: "flex", alignItems: "center", gap: "5px", cursor: "pointer" }}>
+								<input type="checkbox" checked={settings.checkHalfKana} onChange={(e) => handleSettingChange("checkHalfKana", e.target.checked)} style={{ all: "revert" }} />
+								Check Half-width Kana
+							</label>
+							<label style={{ display: "flex", alignItems: "center", gap: "5px", cursor: "pointer" }}>
+								<input type="checkbox" checked={settings.excludeHtml} onChange={(e) => handleSettingChange("excludeHtml", e.target.checked)} style={{ all: "revert" }} />
+								Exclude HTML
+							</label>
+                            <label style={{ display: "flex", alignItems: "center", gap: "5px", cursor: "pointer" }}>
+								<input type="checkbox" checked={settings.excludeUrls} onChange={(e) => handleSettingChange("excludeUrls", e.target.checked)} style={{ all: "revert" }} />
+								Exclude URLs
+							</label>
+						</div>
+                        <div style={{ marginTop: "15px", display: "grid", gridTemplateColumns: "120px 1fr", gap: "10px", alignItems: "center", fontSize: "0.9rem" }}>
+                            <label htmlFor="specificString">Specific String:</label>
+                            <input id="specificString" type="text" value={settings.specificString} onChange={(e) => handleSettingChange("specificString", e.target.value)} style={{ all: "revert", padding: "2px 4px" }} placeholder="Count occurrences..." />
+                        </div>
+                        <div style={{ marginTop: "10px", display: "grid", gridTemplateColumns: "120px 1fr", gap: "10px", alignItems: "center", fontSize: "0.9rem" }}>
+                            <label htmlFor="targetLength">Target Length:</label>
+                            <input id="targetLength" type="number" value={settings.targetLength} onChange={(e) => handleSettingChange("targetLength", Number(e.target.value))} style={{ all: "revert", padding: "2px 4px" }} />
+                        </div>
+                        <div style={{ marginTop: "10px", display: "grid", gridTemplateColumns: "120px 1fr", gap: "10px", alignItems: "center", fontSize: "0.9rem" }}>
+                            <label htmlFor="maxLength">Max Length:</label>
+                            <input id="maxLength" type="number" value={settings.maxLength} onChange={(e) => handleSettingChange("maxLength", Number(e.target.value))} style={{ all: "revert", padding: "2px 4px" }} />
+                        </div>
+					</fieldset>
 				</div>
+
+				{/* Right: Statistics */}
+				<div style={{ flex: "1 1 300px", display: "flex", flexDirection: "column", gap: "20px" }}>
+					
+					{/* Progress Bars */}
+					<fieldset style={{ border: "1px solid #ccc", padding: "15px" }}>
+						<legend>Progress</legend>
+						<div style={{ display: "flex", flexDirection: "column", gap: "15px" }}>
+							
+							{/* Target Progress */}
+							<div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+								<div style={{ display: "flex", justifyContent: "space-between", fontSize: "0.85rem" }}>
+									<span>Target: {stats.totalCharacters} chars</span>
+									<span>{settings.targetLength}</span>
+								</div>
+								<progress 
+									value={stats.totalCharacters} 
+									max={settings.targetLength} 
+									style={{ all: "revert", width: "100%", height: "15px" }} 
+								/>
+							</div>
+
+							{/* Max Limit Progress */}
+							<div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+								<div style={{ display: "flex", justifyContent: "space-between", fontSize: "0.85rem" }}>
+									<span>Max Limit: {stats.totalCharacters} chars</span>
+									<span>{settings.maxLength}</span>
+								</div>
+								<progress 
+									value={stats.totalCharacters} 
+									max={settings.maxLength} 
+									style={{ all: "revert", width: "100%", height: "15px" }} 
+								/>
+							</div>
+
+						</div>
+					</fieldset>
+
+					{/* Basic Stats Table */}
+					<fieldset style={{ border: "1px solid #ccc", padding: "15px" }}>
+						<legend>Basic Statistics</legend>
+						<table style={{ width: "100%", borderCollapse: "collapse", textAlign: "left", fontSize: "0.95rem" }}>
+							<tbody>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Total Characters</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.totalCharacters}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>No Spaces</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.charactersWithoutSpaces}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Words</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.wordCount}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Lines</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.lineCount}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Paragraphs</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.paragraphCount}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Sentences</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.sentenceCount}</td>
+								</tr>
+                                <tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Byte Size (UTF-8)</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.byteSizeUTF8} B</td>
+								</tr>
+                                <tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>400-char Pages</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.manuscriptPages400.toFixed(1)}</td>
+								</tr>
+							</tbody>
+						</table>
+					</fieldset>
+
+					{/* Character Types Table */}
+					<fieldset style={{ border: "1px solid #ccc", padding: "15px" }}>
+						<legend>Character Types</legend>
+						<table style={{ width: "100%", borderCollapse: "collapse", textAlign: "left", fontSize: "0.95rem" }}>
+							<tbody>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Hiragana</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.characterTypes.hiragana}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Katakana</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.characterTypes.katakana}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Kanji</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.characterTypes.kanji}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Alphanumeric</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.characterTypes.alphanumeric}</td>
+								</tr>
+								<tr style={{ borderBottom: "1px solid #eee" }}>
+									<th style={{ padding: "6px 0", fontWeight: "normal" }}>Symbols</th>
+									<td style={{ padding: "6px 0", textAlign: "right" }}>{stats.characterTypes.symbols}</td>
+								</tr>
+                                {settings.specificString && (
+                                    <tr style={{ borderBottom: "1px solid #eee", backgroundColor: "#f9f9f9" }}>
+                                        <th style={{ padding: "6px 0", fontWeight: "bold" }}>"{settings.specificString}"</th>
+                                        <td style={{ padding: "6px 0", textAlign: "right", fontWeight: "bold" }}>{stats.specificStringCount}</td>
+                                    </tr>
+                                )}
+							</tbody>
+						</table>
+					</fieldset>
+
+					{/* Tokenizer */}
+					<details 
+						style={{ border: "1px solid #ccc", padding: "10px" }}
+						onToggle={(e) => setIsTokenizerOpen((e.target as HTMLDetailsElement).open)}
+					>
+						<summary style={{ cursor: "pointer", fontSize: "0.95rem" }}>
+							Tokenizer (o200k_base) - <strong>{tokenData.count !== null ? tokenData.count : "Click to calculate"}</strong> Tokens
+						</summary>
+						<div style={{ marginTop: "10px", padding: "10px", border: "1px solid #eee", backgroundColor: "#fff", maxHeight: "300px", overflowY: "auto", fontSize: "0.95rem", whiteSpace: "pre-wrap", wordBreak: "break-all", lineHeight: "1.4" }}>
+							{tokenData.blocks.map((block, i) => {
+								const colors = ['#ffecb3', '#b3e5fc', '#c8e6c9', '#f8bbd0', '#e1bee7'];
+								const color = colors[i % colors.length];
+								return <span key={i} style={{ backgroundColor: color }} title={`Token ID: ${block.id}`}>{block.str}</span>;
+							})}
+							{tokenData.blocks.length === 0 && isTokenizerOpen && text.length > 0 && <span>Loading tokens...</span>}
+							{text.length === 0 && <span style={{ color: "#999" }}>[ No Data ]</span>}
+						</div>
+					</details>
+				</div>
+
 			</div>
-		</div>
+		</RawDOMContainer>
 	);
 }

--- a/src/app/tools/text-counter/components/TextInput.tsx
+++ b/src/app/tools/text-counter/components/TextInput.tsx
@@ -44,7 +44,7 @@ export default function TextInput({
 				className={`
           w-full h-96 p-4 rounded-xl
           bg-base/75 backdrop-blur-md shadow-[0_8px_24px_rgba(0,0,0,0.25)]
-          focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-base
+          focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent
           resize-none
           ${fontSizeClasses[fontSize]}
         `}

--- a/src/app/tools/text-counter/page.tsx
+++ b/src/app/tools/text-counter/page.tsx
@@ -54,38 +54,5 @@ const jsonLd = {
 };
 
 export default function TextCounterPage() {
-	return (
-		<>
-			<script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-			<div className="relative min-h-screen bg-base text-main">
-				<main className="relative z-10 min-h-screen py-10" tabIndex={-1}>
-					<div className="container-system">
-						<div className="mx-auto w-full max-w-6xl space-y-16 px-4 sm:px-6 lg:px-8">
-							<Breadcrumbs
-								items={[
-									{ label: "Home", href: "/" },
-									{ label: "Tools", href: "/tools" },
-									{ label: "Text Counter", isCurrent: true },
-								]}
-								className="pt-4"
-							/>
-
-							<header className="space-y-6">
-								<h1 className="neue-haas-grotesk-display text-4xl text-main sm:text-5xl lg:text-6xl">
-									Text Counter
-								</h1>
-								<p className="noto-sans-jp-light text-sm text-main/70 leading-relaxed max-w-2xl">
-									テキストの文字数を詳細にカウント.総文字数、単語数、行数、文字種別など豊富な統計情報を提供します.
-								</p>
-							</header>
-
-							<section className="space-y-6">
-								<TextCounterTool />
-							</section>
-						</div>
-					</div>
-				</main>
-			</div>
-		</>
-	);
+	return <TextCounterTool />;
 }

--- a/src/app/tools/text-counter/types/index.ts
+++ b/src/app/tools/text-counter/types/index.ts
@@ -25,6 +25,12 @@ export interface TextStats {
 	longestLineLength: number;
 	characterDensity: number;
 	averageWordsPerLine: number;
+
+	// New advanced statistics
+	manuscriptPages400: number;
+	halfKanaCount: number;
+	specificStringCount: number;
+	byteSizeUTF8: number;
 }
 
 export interface CountSettings {
@@ -32,6 +38,15 @@ export interface CountSettings {
 	includeNewlines: boolean;
 	includeWhitespace: boolean;
 	countMethod: "all" | "visible" | "printable";
+	
+	// New advanced settings
+	targetLength: number;
+	minLength: number;
+	maxLength: number;
+	checkHalfKana: boolean;
+	specificString: string;
+	excludeHtml: boolean;
+	excludeUrls: boolean;
 }
 
 export interface DisplaySettings {

--- a/src/app/tools/text-counter/utils/textAnalysis.ts
+++ b/src/app/tools/text-counter/utils/textAnalysis.ts
@@ -11,11 +11,10 @@ const KANJI_RANGE = /[\u4E00-\u9FAF]/g;
 const ALPHANUMERIC_RANGE = /[A-Za-z0-9]/g;
 
 export function calculateTextStats(
-	text: string,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	_settings: CountSettings,
+	rawText: string,
+	settings: CountSettings,
 ): TextStats {
-	if (!text) {
+	if (!rawText) {
 		return {
 			totalCharacters: 0,
 			charactersWithoutSpaces: 0,
@@ -36,7 +35,20 @@ export function calculateTextStats(
 			longestLineLength: 0,
 			characterDensity: 0,
 			averageWordsPerLine: 0,
+			manuscriptPages400: 0,
+			halfKanaCount: 0,
+			specificStringCount: 0,
+			byteSizeUTF8: 0,
 		};
+	}
+
+	// Apply exclusions
+	let text = rawText;
+	if (settings.excludeHtml) {
+		text = text.replace(/<[^>]*>?/gm, "");
+	}
+	if (settings.excludeUrls) {
+		text = text.replace(/https?:\/\/[^\s]+/g, "");
 	}
 
 	// Basic character counts
@@ -79,6 +91,23 @@ export function calculateTextStats(
 	const averageWordsPerLine =
 		nonEmptyLines.length > 0 ? wordCount / nonEmptyLines.length : 0;
 
+	// Advanced statistics
+	const manuscriptPages400 = Math.ceil(totalCharacters / 400);
+	const halfKanaCount = settings.checkHalfKana
+		? (text.match(/[\uFF61-\uFF9F]/g) || []).length
+		: 0;
+	
+	let specificStringCount = 0;
+	if (settings.specificString && settings.specificString.length > 0) {
+		// Escape special regex characters in the specific string
+		const escapedString = settings.specificString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const regex = new RegExp(escapedString, "g");
+		specificStringCount = (text.match(regex) || []).length;
+	}
+
+	// Calculate UTF-8 byte size
+	const byteSizeUTF8 = new Blob([text]).size;
+
 	return {
 		totalCharacters,
 		charactersWithoutSpaces,
@@ -93,6 +122,10 @@ export function calculateTextStats(
 		longestLineLength,
 		characterDensity,
 		averageWordsPerLine,
+		manuscriptPages400,
+		halfKanaCount,
+		specificStringCount,
+		byteSizeUTF8,
 	};
 }
 


### PR DESCRIPTION
Refactors and enhances the Text Counter tool with new settings and statistics.

Co-Authored-By: rebuildup <rebuild.up.up@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI refactors across multiple tools (notably `text-counter`, `qr-generator`, and `color-palette`) plus changes to shared `ToolWrapper` shortcut handling and new dependencies increase risk of UX/accessibility regressions and broken tool interactions.
> 
> **Overview**
> Refactors several tools to use a new fixed, inline-styled `RawDOMContainer` layout and removes tool-specific keyboard-shortcut wiring (no more `toolShortcut` dispatch or shortcut hint rendering in `ToolWrapper`/`AccessibleButton`).
> 
> Major tool changes: **Text Counter** adds new counting options (exclude HTML/URLs, half-width kana detection, specific-string occurrence counting), new stats (UTF-8 byte size, 400-char manuscript pages, length targets/limits), and a token counter view using `js-tiktoken`. **QR Generator** replaces the custom QR matrix renderer with the `qrcode` library and adds bulk (multi-line) generation plus batched PNG/SVG downloads. **Color Palette Generator** is heavily simplified (drops offline/perf/accessibility/palette-import features) and reworked into a minimal UI with basic generation/sorting/preset ranges, saved palettes, and simplified exports.
> 
> Also updates multiple tools/pages to remove `bg-base` wrappers, tweaks focus-ring styling in accessible form components, switches Tools list cards to `GlowCard`, and fixes the About page Links route to `/about/links`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a4a4441d9332680a681fd5922b6cfadd219620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->